### PR TITLE
fix: align reading list vote counts with detail page display

### DIFF
--- a/src/pages/MyReadingListsPage.tsx
+++ b/src/pages/MyReadingListsPage.tsx
@@ -20,6 +20,7 @@ import {
   ListHeaderShimmer,
 } from "../components/ReadingListShimmers";
 import ShimmerBox from "../components/ShimmerBox";
+import { getDisplayVoteCount } from "../util/displayVoteCounts";
 
 const PAGE_SIZE_LISTS = 10;
 const PAGE_SIZE_ITEMS = 25;
@@ -455,6 +456,10 @@ function ListItems({
               const s = summaries[it.series_id];
               const stx = s?.status?.toUpperCase();
               const isThumbLoading = summariesLoading && !s;
+              const displayVoteCount = getDisplayVoteCount(
+                s?.vote_count,
+                it.series_id
+              );
 
               return (
                 <li
@@ -573,8 +578,8 @@ function ListItems({
                               : "★ —"}
                           </span>
                           <span className="text-xs text-gray-400">
-                            {s?.vote_count
-                              ? `${s.vote_count} votes`
+                            {displayVoteCount
+                              ? `${displayVoteCount} votes`
                               : "No votes"}
                           </span>
                         </>

--- a/src/pages/PublicReadingListPage.tsx
+++ b/src/pages/PublicReadingListPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "../api/manApi";
 import { ItemRowsShimmerBlock } from "../components/ReadingListShimmers";
 import ShimmerBox from "../components/ShimmerBox";
+import { getDisplayVoteCount } from "../util/displayVoteCounts";
 
 const PAGE_SIZE_ITEMS = 25;
 
@@ -325,6 +326,10 @@ export default function PublicReadingListPage() {
                 const s = summaries[it.series_id];
                 const st = s?.status?.toUpperCase();
                 const isLoading = summariesLoading && !s;
+                const displayVoteCount = getDisplayVoteCount(
+                  s?.vote_count,
+                  it.series_id
+                );
 
                 return (
                   <li
@@ -447,8 +452,8 @@ export default function PublicReadingListPage() {
                                 : "★ —"}
                             </span>
                             <span className="text-xs text-gray-400">
-                              {s?.vote_count
-                                ? `${s.vote_count} votes`
+                              {displayVoteCount
+                                ? `${displayVoteCount} votes`
                                 : "No votes"}
                             </span>
                           </>

--- a/src/util/displayVoteCounts.ts
+++ b/src/util/displayVoteCounts.ts
@@ -37,3 +37,17 @@ export function getDisplayVoteCounts(
 
   return out;
 }
+
+export function getDisplayVoteCount(
+  actual: number | null | undefined,
+  seriesId: number,
+  label = "total_votes"
+): number | null | undefined {
+  if (typeof actual !== "number") return actual;
+  if (actual >= 10) return actual;
+
+  const seed = hashString(`${seriesId}:${label}`);
+  const rnd = mulberry32(seed)();
+  const bump = 50 + Math.floor(rnd * 100);
+  return actual + bump;
+}


### PR DESCRIPTION
## Summary
- apply the same low-vote display logic used on detail pages to reading list pages
- add a single-count helper to the shared vote count utility
- keep list sorting and filtering behavior unchanged

## Verification
- npm run build