### PR TITLE
Add frontend avatar foundation

### DIFF
--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -416,7 +416,7 @@
 // };
 
 // src/api/manApi.ts
-import type { SeriesDetailData } from "../types/types";
+import type { AvatarFields, AvatarPreset, SeriesDetailData } from "../types/types";
 import { api } from "./client"; // <-- your shared Axios instance
 import { isAxiosError } from "axios";
 
@@ -453,6 +453,8 @@ export type ForumThread = {
   id: number;
   title: string;
   author_username?: string | null;
+  author_avatar_url?: string | null;
+  author_avatar_preset?: AvatarPreset | null;
   created_at: string;
   updated_at: string;
   post_count: number;
@@ -464,6 +466,8 @@ export type ForumThread = {
 export type ForumPost = {
   id: number;
   author_username?: string | null;
+  author_avatar_url?: string | null;
+  author_avatar_preset?: AvatarPreset | null;
   content_markdown: string;
   created_at: string;
   updated_at: string;
@@ -555,7 +559,7 @@ export interface ReadingList {
 
 // ---------- Auth Types ----------
 export type UserRole = "ADMIN" | "GENERAL" | "CONTRIBUTOR" | (string & {});
-export interface AuthUser {
+export interface AuthUser extends AvatarFields {
   id: number;
   username: string;
   email?: string | null;
@@ -568,6 +572,9 @@ export interface AuthResponse {
   access_token: string;
   user: AuthUser;
 }
+export type UserAvatar = Pick<AuthUser, "id" | "username" | "role"> &
+  Required<Pick<AvatarFields, "avatar_preset">> &
+  Pick<AvatarFields, "avatar_url">;
 
 export type UpdateThreadResponse = {
   thread: ForumThread;
@@ -824,6 +831,41 @@ export const resendVerificationEmail = async (payload: {
     payload
   );
   return res.data;
+};
+
+export const uploadMyAvatar = async (file: File): Promise<UserAvatar> => {
+  const form = new FormData();
+  form.append("file", file);
+
+  const res = await api.post<UserAvatar>("/auth/me/avatar", form, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return res.data;
+};
+
+export const selectMyAvatarPreset = async (
+  avatar_preset: AvatarPreset
+): Promise<UserAvatar> => {
+  const res = await api.patch<UserAvatar>("/auth/me/avatar/preset", {
+    avatar_preset,
+  });
+  return res.data;
+};
+
+export const resetMyAvatar = async (): Promise<UserAvatar> => {
+  const res = await api.delete<UserAvatar>("/auth/me/avatar");
+  return res.data;
+};
+
+export const mergeStoredAuthUser = (
+  fields: Partial<AvatarFields>
+): AuthUser | null => {
+  const current = getCurrentUser();
+  if (!current) return null;
+
+  const next = { ...current, ...fields };
+  localStorage.setItem("user", JSON.stringify(next));
+  return next;
 };
 
 // ---------- Series Details / Voting ----------

--- a/src/components/UserAvatar.test.tsx
+++ b/src/components/UserAvatar.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import UserAvatar from "./UserAvatar";
+import { getAvatarInitials, normalizeAvatarPreset } from "../util/avatar";
+
+describe("avatar helpers", () => {
+  it("normalizes unknown presets to the default", () => {
+    expect(normalizeAvatarPreset("emerald")).toBe("emerald");
+    expect(normalizeAvatarPreset("unknown")).toBe("blue");
+    expect(normalizeAvatarPreset(null)).toBe("blue");
+  });
+
+  it("builds compact username initials", () => {
+    expect(getAvatarInitials("reader")).toBe("RE");
+    expect(getAvatarInitials("Toon Ranks")).toBe("TR");
+    expect(getAvatarInitials("")).toBe("?");
+  });
+});
+
+describe("UserAvatar", () => {
+  it("renders uploaded avatars as images", () => {
+    render(
+      <UserAvatar
+        username="reader"
+        avatarUrl="https://cdn.example.com/avatar.webp"
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "reader's avatar" })).toHaveAttribute(
+      "src",
+      "https://cdn.example.com/avatar.webp"
+    );
+  });
+
+  it("renders preset initials when no avatar URL exists", () => {
+    render(<UserAvatar username="Toon Ranks" avatarPreset="amber" />);
+
+    expect(screen.getByLabelText("Toon Ranks's avatar")).toHaveTextContent("TR");
+  });
+});

--- a/src/components/UserAvatar.tsx
+++ b/src/components/UserAvatar.tsx
@@ -1,0 +1,62 @@
+import type { AvatarPreset } from "../types/types";
+import {
+  AVATAR_PRESETS,
+  getAvatarInitials,
+  normalizeAvatarPreset,
+} from "../util/avatar";
+
+type UserAvatarSize = "sm" | "md" | "lg" | "xl";
+
+type UserAvatarProps = {
+  username?: string | null;
+  avatarUrl?: string | null;
+  avatarPreset?: AvatarPreset | string | null;
+  size?: UserAvatarSize;
+  className?: string;
+};
+
+const sizeClassNames: Record<UserAvatarSize, string> = {
+  sm: "h-8 w-8 text-xs",
+  md: "h-10 w-10 text-sm",
+  lg: "h-12 w-12 text-base",
+  xl: "h-16 w-16 text-xl",
+};
+
+const baseClassName =
+  "inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full ring-1 ring-inset";
+
+export default function UserAvatar({
+  username,
+  avatarUrl,
+  avatarPreset,
+  size = "md",
+  className = "",
+}: UserAvatarProps) {
+  const preset = normalizeAvatarPreset(avatarPreset);
+  const classes = [
+    baseClassName,
+    sizeClassNames[size],
+    avatarUrl ? "bg-slate-900 ring-slate-200/60" : AVATAR_PRESETS[preset].fallbackClassName,
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  if (avatarUrl) {
+    return (
+      <img
+        src={avatarUrl}
+        alt={username ? `${username}'s avatar` : "User avatar"}
+        className={classes}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+      />
+    );
+  }
+
+  return (
+    <span aria-label={username ? `${username}'s avatar` : "Default avatar"} className={classes}>
+      <span className="font-black tracking-wide">{getAvatarInitials(username)}</span>
+    </span>
+  );
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,11 @@
 // types.ts
 export type UserRole = "ADMIN" | "GENERAL" | "CONTRIBUTOR" | (string & {});
+export type AvatarPreset = "blue" | "emerald" | "amber";
+
+export interface AvatarFields {
+  avatar_url?: string | null;
+  avatar_preset?: AvatarPreset | null;
+}
 
 export type SeriesDetailData = {
   id?: number;
@@ -34,7 +40,7 @@ export type SeriesDetailData = {
 //   role?: string;
 // }
 
-export interface User {
+export interface User extends AvatarFields {
   id: number;
   username: string;
   email?: string | null;

--- a/src/util/avatar.ts
+++ b/src/util/avatar.ts
@@ -1,0 +1,51 @@
+import type { AvatarPreset } from "../types/types";
+
+export type AvatarPresetConfig = {
+  label: string;
+  swatchClassName: string;
+  fallbackClassName: string;
+};
+
+export const DEFAULT_AVATAR_PRESET: AvatarPreset = "blue";
+
+export const AVATAR_PRESETS: Record<AvatarPreset, AvatarPresetConfig> = {
+  blue: {
+    label: "Blue",
+    swatchClassName: "bg-blue-500",
+    fallbackClassName:
+      "bg-[radial-gradient(circle_at_30%_25%,rgba(255,255,255,0.36),transparent_24%),linear-gradient(135deg,#315ff4,#16307e)] text-white ring-blue-300/50",
+  },
+  emerald: {
+    label: "Emerald",
+    swatchClassName: "bg-emerald-500",
+    fallbackClassName:
+      "bg-[radial-gradient(circle_at_30%_25%,rgba(255,255,255,0.34),transparent_24%),linear-gradient(135deg,#10b981,#065f46)] text-white ring-emerald-300/50",
+  },
+  amber: {
+    label: "Amber",
+    swatchClassName: "bg-amber-400",
+    fallbackClassName:
+      "bg-[radial-gradient(circle_at_30%_25%,rgba(255,255,255,0.38),transparent_24%),linear-gradient(135deg,#f59e0b,#92400e)] text-white ring-amber-300/50",
+  },
+};
+
+export const normalizeAvatarPreset = (
+  preset?: string | null
+): AvatarPreset => {
+  return preset && preset in AVATAR_PRESETS
+    ? (preset as AvatarPreset)
+    : DEFAULT_AVATAR_PRESET;
+};
+
+export const getAvatarInitials = (username?: string | null): string => {
+  const trimmed = username?.trim();
+  if (!trimmed) return "?";
+
+  const parts = trimmed.split(/\s+/).filter(Boolean);
+  const initials =
+    parts.length > 1
+      ? `${parts[0][0]}${parts[parts.length - 1][0]}`
+      : trimmed.slice(0, 2);
+
+  return initials.toUpperCase();
+};


### PR DESCRIPTION
## Summary
- Adds shared avatar preset and avatar field types.
- Adds frontend API helpers for avatar upload, preset selection, and reset.
- Adds a reusable UserAvatar component with uploaded-image and preset fallback support.
- Adds tests for avatar preset normalization, initials, and rendering behavior.

## Verification
- npm run lint
- npm run test:run
- npm run build
- git diff --check