### PR TITLE
Show user avatars across account and forum surfaces

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,6 +16,7 @@ import myHomeLogo from "../images/logo/myHomeLogo.png";
 import { useTheme } from "./useTheme";
 import { canSubmitSeriesUser, isAdminUser } from "../util/roleUtils";
 import { searchSeries, type RankedSeries } from "../api/manApi";
+import UserAvatar from "./UserAvatar";
 
 const DEFAULT_LABEL = "ALL";
 
@@ -349,6 +350,12 @@ const Header = () => {
                   onClick={() => setAccountMenuOpen((prev) => !prev)}
                   className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-100 px-3.5 py-2 text-sm font-semibold text-slate-700 ring-1 ring-inset ring-slate-200 transition hover:bg-slate-50 dark-theme-chip dark:text-slate-200"
                 >
+                  <UserAvatar
+                    username={user.username}
+                    avatarUrl={user.avatar_url}
+                    avatarPreset={user.avatar_preset}
+                    size="sm"
+                  />
                   {user.username}
                   <ChevronDownIcon className="h-4 w-4" />
                 </button>
@@ -628,8 +635,14 @@ const Header = () => {
                     <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
                       Account
                     </div>
-                    <div className="mt-1 text-sm font-semibold text-slate-800 dark:text-slate-100">
-                      {user.username}
+                    <div className="mt-2 flex items-center gap-2 text-sm font-semibold text-slate-800 dark:text-slate-100">
+                      <UserAvatar
+                        username={user.username}
+                        avatarUrl={user.avatar_url}
+                        avatarPreset={user.avatar_preset}
+                        size="sm"
+                      />
+                      <span>{user.username}</span>
                     </div>
                   </div>
                   <ChevronDownIcon

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -21,6 +21,7 @@ import { stripMdHeading } from "../util/strings";
 import { ConfirmModal } from "../components/ConfirmModal";
 import { useNotice } from "../hooks/useNotice";
 import { NoticeModal } from "../components/NoticeModal";
+import UserAvatar from "../components/UserAvatar";
 
 const MAX_THREADS_PER_USER = 10;
 const MAX_SERIES_REFS = 10;
@@ -411,10 +412,26 @@ export default function ForumPage() {
                 </div>
 
                 <div className="flex flex-wrap items-center gap-2">
-                  <div className="text-xs text-gray-500 dark:text-stone-400">
-                    {t.post_count} posts - updated{" "}
-                    {new Date(t.updated_at).toLocaleString()}
-                    {t.author_username ? ` - by ${t.author_username}` : null}
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500 dark:text-stone-400">
+                    <span>
+                      {t.post_count} posts - updated{" "}
+                      {new Date(t.updated_at).toLocaleString()}
+                    </span>
+                    {t.author_username ? (
+                      <span className="inline-flex items-center gap-1.5">
+                        <span>- by</span>
+                        <UserAvatar
+                          username={t.author_username}
+                          avatarUrl={t.author_avatar_url}
+                          avatarPreset={t.author_avatar_preset}
+                          size="sm"
+                          className="h-6 w-6 text-[10px]"
+                        />
+                        <span className="font-medium text-slate-700 dark:text-stone-200">
+                          {t.author_username}
+                        </span>
+                      </span>
+                    ) : null}
                   </div>
 
                   {isPatchNotes && (

--- a/src/pages/PendingTitlesPage.tsx
+++ b/src/pages/PendingTitlesPage.tsx
@@ -16,6 +16,7 @@ import { useUser } from "../login/useUser";
 import { isAdminUser } from "../util/roleUtils";
 import { NoIndexSeo } from "../components/Seo";
 import { SITE_NAME } from "../config/site";
+import UserAvatar from "../components/UserAvatar";
 
 const roleOptions: UserRole[] = ["GENERAL", "CONTRIBUTOR", "ADMIN"];
 
@@ -385,7 +386,15 @@ export default function PendingTitlesPage() {
                           {users.map((account) => (
                             <tr key={account.id} className="dark-theme-card-soft">
                               <td className="px-4 py-3 font-medium text-slate-900 dark:text-stone-100">
-                                {account.username}
+                                <span className="inline-flex items-center gap-2">
+                                  <UserAvatar
+                                    username={account.username}
+                                    avatarUrl={account.avatar_url}
+                                    avatarPreset={account.avatar_preset}
+                                    size="sm"
+                                  />
+                                  {account.username}
+                                </span>
                               </td>
                               <td className="px-4 py-3 text-slate-600 dark:text-stone-300">
                                 {account.email || "—"}

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -33,6 +33,7 @@ import { ConfirmModal } from "../components/ConfirmModal";
 import { useNotice } from "../hooks/useNotice";
 import { NoticeModal } from "../components/NoticeModal";
 import { HeartButton } from "../components/HeartButton";
+import UserAvatar from "../components/UserAvatar";
 import {
   DEFAULT_SOCIAL_IMAGE,
   SITE_NAME,
@@ -884,7 +885,16 @@ export default function ThreadPage() {
                     <span className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-1 font-semibold text-blue-700 dark:bg-blue-950/40 dark:text-blue-300">
                       Original post
                     </span>
-                    <span>{posts[0].author_username || "Anonymous"}</span>
+                    <span className="inline-flex items-center gap-1.5 font-medium text-slate-700 dark:text-slate-200">
+                      <UserAvatar
+                        username={posts[0].author_username || "Anonymous"}
+                        avatarUrl={posts[0].author_avatar_url}
+                        avatarPreset={posts[0].author_avatar_preset}
+                        size="sm"
+                        className="h-6 w-6 text-[10px]"
+                      />
+                      {posts[0].author_username || "Anonymous"}
+                    </span>
                     <span>{new Date(posts[0].created_at).toLocaleString()}</span>
                   </div>
 
@@ -1297,7 +1307,14 @@ function ReplyBranch({
             >
               {labelText}
             </span>
-            <span className="font-medium text-slate-700 dark:text-slate-200">
+            <span className="inline-flex items-center gap-1.5 font-medium text-slate-700 dark:text-slate-200">
+              <UserAvatar
+                username={post.author_username || "Anonymous"}
+                avatarUrl={post.author_avatar_url}
+                avatarPreset={post.author_avatar_preset}
+                size="sm"
+                className="h-6 w-6 text-[10px]"
+              />
               {post.author_username || "Anonymous"}
             </span>
             <span>{new Date(post.created_at).toLocaleString()}</span>


### PR DESCRIPTION
## Summary
- Shows user avatars in the signed-in header account controls.
- Adds forum author avatars to thread list rows and thread post/reply author rows.
- Adds avatars to the admin user access table.
- Uses uploaded avatar URLs when present and preset fallback avatars otherwise.

## Verification
- npm run lint
- npm run test:run
- npm run build
- git diff --check