### PR TITLE
Apply role colors to displayed usernames

### DIFF
--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -453,6 +453,7 @@ export type ForumThread = {
   id: number;
   title: string;
   author_username?: string | null;
+  author_role?: UserRole | null;
   author_avatar_url?: string | null;
   author_avatar_preset?: AvatarPreset | null;
   created_at: string;
@@ -466,6 +467,7 @@ export type ForumThread = {
 export type ForumPost = {
   id: number;
   author_username?: string | null;
+  author_role?: UserRole | null;
   author_avatar_url?: string | null;
   author_avatar_preset?: AvatarPreset | null;
   content_markdown: string;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,6 +17,7 @@ import { useTheme } from "./useTheme";
 import { canSubmitSeriesUser, isAdminUser } from "../util/roleUtils";
 import { searchSeries, type RankedSeries } from "../api/manApi";
 import UserAvatar from "./UserAvatar";
+import { inlineUsernameClassName } from "../util/userDisplay";
 
 const DEFAULT_LABEL = "ALL";
 
@@ -356,7 +357,9 @@ const Header = () => {
                     avatarPreset={user.avatar_preset}
                     size="sm"
                   />
-                  {user.username}
+                  <span className={inlineUsernameClassName(user.role)}>
+                    {user.username}
+                  </span>
                   <ChevronDownIcon className="h-4 w-4" />
                 </button>
 
@@ -642,7 +645,9 @@ const Header = () => {
                         avatarPreset={user.avatar_preset}
                         size="sm"
                       />
-                      <span>{user.username}</span>
+                      <span className={inlineUsernameClassName(user.role)}>
+                        {user.username}
+                      </span>
                     </div>
                   </div>
                   <ChevronDownIcon

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -12,6 +12,7 @@ import { NoIndexSeo } from "../components/Seo";
 import { useUser } from "../login/useUser";
 import type { AvatarPreset, User } from "../types/types";
 import { AVATAR_PRESETS, normalizeAvatarPreset } from "../util/avatar";
+import { usernameClassName } from "../util/userDisplay";
 
 type CropDraft = {
   file: File;
@@ -28,20 +29,6 @@ function saveUser(nextUser: User, setUser: (user: User) => void) {
 
 function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max);
-}
-
-function profileNameClassName(role?: string | null) {
-  const normalized = String(role || "").toUpperCase();
-
-  if (normalized === "ADMIN") {
-    return "bg-gradient-to-r from-amber-300 via-orange-300 to-rose-300 bg-clip-text text-transparent";
-  }
-
-  if (normalized === "CONTRIBUTOR") {
-    return "bg-gradient-to-r from-blue-300 via-sky-300 to-cyan-200 bg-clip-text text-transparent";
-  }
-
-  return "text-slate-950 dark:text-white";
 }
 
 async function imageFromFile(file: File): Promise<CropDraft> {
@@ -275,7 +262,7 @@ export default function AccountPage() {
               className="h-28 w-28 text-4xl"
             />
             <h2
-              className={`mt-5 text-2xl font-black ${profileNameClassName(
+              className={`mt-5 text-2xl font-black ${usernameClassName(
                 user.role
               )}`}
             >

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -22,6 +22,7 @@ import { ConfirmModal } from "../components/ConfirmModal";
 import { useNotice } from "../hooks/useNotice";
 import { NoticeModal } from "../components/NoticeModal";
 import UserAvatar from "../components/UserAvatar";
+import { inlineUsernameClassName } from "../util/userDisplay";
 
 const MAX_THREADS_PER_USER = 10;
 const MAX_SERIES_REFS = 10;
@@ -427,7 +428,11 @@ export default function ForumPage() {
                           size="sm"
                           className="h-6 w-6 text-[10px]"
                         />
-                        <span className="font-medium text-slate-700 dark:text-stone-200">
+                        <span
+                          className={`font-medium ${inlineUsernameClassName(
+                            t.author_role
+                          )}`}
+                        >
                           {t.author_username}
                         </span>
                       </span>

--- a/src/pages/PendingTitlesPage.tsx
+++ b/src/pages/PendingTitlesPage.tsx
@@ -17,6 +17,7 @@ import { isAdminUser } from "../util/roleUtils";
 import { NoIndexSeo } from "../components/Seo";
 import { SITE_NAME } from "../config/site";
 import UserAvatar from "../components/UserAvatar";
+import { inlineUsernameClassName } from "../util/userDisplay";
 
 const roleOptions: UserRole[] = ["GENERAL", "CONTRIBUTOR", "ADMIN"];
 
@@ -393,7 +394,9 @@ export default function PendingTitlesPage() {
                                     avatarPreset={account.avatar_preset}
                                     size="sm"
                                   />
-                                  {account.username}
+                                  <span className={inlineUsernameClassName(account.role)}>
+                                    {account.username}
+                                  </span>
                                 </span>
                               </td>
                               <td className="px-4 py-3 text-slate-600 dark:text-stone-300">

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -34,6 +34,7 @@ import { useNotice } from "../hooks/useNotice";
 import { NoticeModal } from "../components/NoticeModal";
 import { HeartButton } from "../components/HeartButton";
 import UserAvatar from "../components/UserAvatar";
+import { inlineUsernameClassName } from "../util/userDisplay";
 import {
   DEFAULT_SOCIAL_IMAGE,
   SITE_NAME,
@@ -885,7 +886,7 @@ export default function ThreadPage() {
                     <span className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-1 font-semibold text-blue-700 dark:bg-blue-950/40 dark:text-blue-300">
                       Original post
                     </span>
-                    <span className="inline-flex items-center gap-1.5 font-medium text-slate-700 dark:text-slate-200">
+                    <span className="inline-flex items-center gap-1.5 font-medium">
                       <UserAvatar
                         username={posts[0].author_username || "Anonymous"}
                         avatarUrl={posts[0].author_avatar_url}
@@ -893,7 +894,9 @@ export default function ThreadPage() {
                         size="sm"
                         className="h-6 w-6 text-[10px]"
                       />
-                      {posts[0].author_username || "Anonymous"}
+                      <span className={inlineUsernameClassName(posts[0].author_role)}>
+                        {posts[0].author_username || "Anonymous"}
+                      </span>
                     </span>
                     <span>{new Date(posts[0].created_at).toLocaleString()}</span>
                   </div>
@@ -1307,7 +1310,7 @@ function ReplyBranch({
             >
               {labelText}
             </span>
-            <span className="inline-flex items-center gap-1.5 font-medium text-slate-700 dark:text-slate-200">
+            <span className="inline-flex items-center gap-1.5 font-medium">
               <UserAvatar
                 username={post.author_username || "Anonymous"}
                 avatarUrl={post.author_avatar_url}
@@ -1315,7 +1318,9 @@ function ReplyBranch({
                 size="sm"
                 className="h-6 w-6 text-[10px]"
               />
-              {post.author_username || "Anonymous"}
+              <span className={inlineUsernameClassName(post.author_role)}>
+                {post.author_username || "Anonymous"}
+              </span>
             </span>
             <span>{new Date(post.created_at).toLocaleString()}</span>
           </div>

--- a/src/util/userDisplay.ts
+++ b/src/util/userDisplay.ts
@@ -1,0 +1,27 @@
+export function usernameClassName(role?: string | null): string {
+  const normalized = String(role || "").toUpperCase();
+
+  if (normalized === "ADMIN") {
+    return "bg-gradient-to-r from-amber-300 via-orange-300 to-rose-300 bg-clip-text text-transparent";
+  }
+
+  if (normalized === "CONTRIBUTOR") {
+    return "bg-gradient-to-r from-blue-300 via-sky-300 to-cyan-200 bg-clip-text text-transparent";
+  }
+
+  return "text-slate-950 dark:text-white";
+}
+
+export function inlineUsernameClassName(role?: string | null): string {
+  const normalized = String(role || "").toUpperCase();
+
+  if (normalized === "ADMIN") {
+    return "bg-gradient-to-r from-amber-300 via-orange-300 to-rose-300 bg-clip-text text-transparent";
+  }
+
+  if (normalized === "CONTRIBUTOR") {
+    return "bg-gradient-to-r from-blue-300 via-sky-300 to-cyan-200 bg-clip-text text-transparent";
+  }
+
+  return "text-slate-700 dark:text-slate-200";
+}


### PR DESCRIPTION
## Summary
- Centralizes role-based username color styling.
- Applies admin/contributor username colors across header, account, forum, thread, and admin user surfaces.
- Adds optional forum author role typing so forum names can use backend role metadata.

## Verification
- npm run lint
- npm run test:run
- npm run build
- git diff --check