### PR TITLE
Add web mobile auth redirect bridge

### DIFF
--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -574,6 +574,11 @@ export interface AuthResponse {
   access_token: string;
   user: AuthUser;
 }
+export interface MobileAuthCodeResponse {
+  code: string;
+  expires_in: number;
+  redirect_url: string;
+}
 export type UserAvatar = Pick<AuthUser, "id" | "username" | "role"> &
   Required<Pick<AvatarFields, "avatar_preset">> &
   Pick<AvatarFields, "avatar_url">;
@@ -813,6 +818,17 @@ export const googleOAuthLogin = async (
   // Keep existing behavior: persist token + user here
   localStorage.setItem("token", res.data.access_token);
   localStorage.setItem("user", JSON.stringify(res.data.user));
+  return res.data;
+};
+
+export const createMobileAuthCode = async (payload: {
+  redirect_uri: string;
+  state?: string | null;
+}): Promise<MobileAuthCodeResponse> => {
+  const res = await api.post<MobileAuthCodeResponse>("/auth/mobile-code", {
+    redirect_uri: payload.redirect_uri,
+    state: payload.state ?? null,
+  });
   return res.data;
 };
 

--- a/src/components/GoogleOAuthButton.tsx
+++ b/src/components/GoogleOAuthButton.tsx
@@ -5,8 +5,13 @@ import { googleOAuthLogin } from "../api/manApi";
 import type { CredentialResponse } from "@react-oauth/google";
 import { scheduleLogoutAtJwtExp } from "../util/authUtils";
 import { useUser } from "../login/useUser";
+import type { AuthResponse } from "../api/manApi";
 
-const GoogleOAuthButton = () => {
+type GoogleOAuthButtonProps = {
+  onAuthenticated?: (data: AuthResponse) => Promise<void> | void;
+};
+
+const GoogleOAuthButton = ({ onAuthenticated }: GoogleOAuthButtonProps) => {
   const navigate = useNavigate();
   const { setUser } = useUser();
 
@@ -35,7 +40,11 @@ const GoogleOAuthButton = () => {
       // }, 10 * 60 * 60 * 1000);
       // handleAutoLogout(setUser);
       scheduleLogoutAtJwtExp(setUser, data.access_token);
-      navigate("/");
+      if (onAuthenticated) {
+        await onAuthenticated(data);
+      } else {
+        navigate("/");
+      }
     } catch (err) {
       alert("Google login failed");
       console.error("Google OAuth error:", err);

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,13 +1,22 @@
 import { useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import ReCAPTCHA from "react-google-recaptcha";
-import { login, resendVerificationEmail } from "../api/manApi";
+import {
+  createMobileAuthCode,
+  login,
+  resendVerificationEmail,
+} from "../api/manApi";
+import type { AuthResponse } from "../api/manApi";
 import GoogleOAuthButton from "../components/GoogleOAuthButton";
 import AuthShell from "../components/AuthShell";
 import { scheduleLogoutAtJwtExp } from "../util/authUtils";
 import { useUser } from "../login/useUser";
 import { NoIndexSeo } from "../components/Seo";
 import { SITE_NAME } from "../config/site";
+import {
+  getMobileAuthRequest,
+  redirectToMobileAuthCallback,
+} from "../util/mobileAuthRedirect";
 
 const fieldClass =
   "mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-300 focus:bg-white focus:ring-4 focus:ring-blue-100 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(22,18,15,0.98),_rgba(18,15,12,0.98))] dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-[#4a3c33] dark:focus:bg-[#181310] dark:focus:ring-[#2a221c]";
@@ -17,6 +26,7 @@ const LoginPage = () => {
   const [password, setPassword] = useState("");
   const { setUser } = useUser();
   const navigate = useNavigate();
+  const location = useLocation();
   const [error, setError] = useState<string | null>(null);
   const [captchaToken, setCaptchaToken] = useState("");
 
@@ -28,6 +38,26 @@ const LoginPage = () => {
   const [resendMsg, setResendMsg] = useState<string | null>(null);
   const [resending, setResending] = useState(false);
   const [resendCaptcha, setResendCaptcha] = useState("");
+  const mobileAuthRequest = getMobileAuthRequest(location.search);
+
+  const finishAuthenticatedSession = async (data: AuthResponse) => {
+    setUser(data.user);
+    localStorage.setItem("token", data.access_token);
+    localStorage.setItem("user", JSON.stringify(data.user));
+    scheduleLogoutAtJwtExp(setUser, data.access_token);
+    setError(null);
+
+    if (mobileAuthRequest.isMobile && mobileAuthRequest.redirectUri) {
+      const mobileCode = await createMobileAuthCode({
+        redirect_uri: mobileAuthRequest.redirectUri,
+        state: mobileAuthRequest.state,
+      });
+      redirectToMobileAuthCallback(mobileCode.redirect_url);
+      return;
+    }
+
+    navigate("/");
+  };
 
   const handleLogin = async () => {
     setError(null);
@@ -50,12 +80,7 @@ const LoginPage = () => {
         password,
         captcha_token: captchaToken,
       });
-      setUser(data.user);
-      localStorage.setItem("token", data.access_token);
-      localStorage.setItem("user", JSON.stringify(data.user));
-      scheduleLogoutAtJwtExp(setUser, data.access_token);
-      setError(null);
-      navigate("/");
+      await finishAuthenticatedSession(data);
     } catch (err) {
       const msg = (err as Error).message || "";
       console.error("Login error:", msg);
@@ -74,6 +99,8 @@ const LoginPage = () => {
         statusCode === "400"
       ) {
         setError("CAPTCHA expired. Please try again.");
+      } else if (mobileAuthRequest.isMobile) {
+        setError("Login succeeded, but returning to the app failed. Please try again.");
       } else {
         setError("Login failed. Please try again.");
       }
@@ -260,7 +287,7 @@ const LoginPage = () => {
         </div>
 
         <div className="rounded-[24px] border border-slate-200 bg-slate-50/70 px-4 py-4 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(25,21,18,0.96),_rgba(20,17,14,0.96))]">
-          <GoogleOAuthButton />
+          <GoogleOAuthButton onAuthenticated={finishAuthenticatedSession} />
         </div>
       </div>
     </AuthShell>

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -1,11 +1,19 @@
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import ReCAPTCHA from "react-google-recaptcha";
-import { signup } from "../api/manApi";
+import { createMobileAuthCode, signup } from "../api/manApi";
+import type { AuthResponse } from "../api/manApi";
 import GoogleOAuthButton from "../components/GoogleOAuthButton";
 import AuthShell from "../components/AuthShell";
 import { NoIndexSeo } from "../components/Seo";
 import { SITE_NAME } from "../config/site";
+import { useUser } from "../login/useUser";
+import { scheduleLogoutAtJwtExp } from "../util/authUtils";
+import {
+  buildMobileSignupVerificationRedirect,
+  getMobileAuthRequest,
+  redirectToMobileAuthCallback,
+} from "../util/mobileAuthRedirect";
 
 const fieldClass =
   "mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-emerald-300 focus:bg-white focus:ring-4 focus:ring-emerald-100 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(22,18,15,0.98),_rgba(18,15,12,0.98))] dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-[#4a3c33] dark:focus:bg-[#181310] dark:focus:ring-[#2a221c]";
@@ -14,11 +22,32 @@ const SignupPage = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [email, setEmail] = useState("");
+  const { setUser } = useUser();
   const navigate = useNavigate();
+  const location = useLocation();
   const [captchaToken, setCaptchaToken] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const mobileAuthRequest = getMobileAuthRequest(location.search);
+
+  const finishAuthenticatedSession = async (data: AuthResponse) => {
+    setUser(data.user);
+    localStorage.setItem("token", data.access_token);
+    localStorage.setItem("user", JSON.stringify(data.user));
+    scheduleLogoutAtJwtExp(setUser, data.access_token);
+
+    if (mobileAuthRequest.isMobile && mobileAuthRequest.redirectUri) {
+      const mobileCode = await createMobileAuthCode({
+        redirect_uri: mobileAuthRequest.redirectUri,
+        state: mobileAuthRequest.state,
+      });
+      redirectToMobileAuthCallback(mobileCode.redirect_url);
+      return;
+    }
+
+    navigate("/");
+  };
 
   const handleSignup = async () => {
     const u = username.trim();
@@ -47,6 +76,12 @@ const SignupPage = () => {
       });
 
       setInfo("Signup successful. Please verify your email.");
+      const mobileRedirect =
+        buildMobileSignupVerificationRedirect(mobileAuthRequest);
+      if (mobileRedirect) {
+        redirectToMobileAuthCallback(mobileRedirect);
+        return;
+      }
       navigate("/check-your-email");
     } catch (err) {
       const raw = err instanceof Error ? err.message : "0:Signup failed";
@@ -197,7 +232,7 @@ const SignupPage = () => {
         </div>
 
         <div className="rounded-[24px] border border-slate-200 bg-slate-50/70 px-4 py-4 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(25,21,18,0.96),_rgba(20,17,14,0.96))]">
-          <GoogleOAuthButton />
+          <GoogleOAuthButton onAuthenticated={finishAuthenticatedSession} />
         </div>
       </div>
     </AuthShell>

--- a/src/util/mobileAuthRedirect.test.ts
+++ b/src/util/mobileAuthRedirect.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildMobileSignupVerificationRedirect,
+  getMobileAuthRequest,
+  redirectToMobileAuthCallback,
+} from "./mobileAuthRedirect";
+
+describe("mobile auth redirect helpers", () => {
+  it("recognizes valid mobile auth requests", () => {
+    const request = getMobileAuthRequest(
+      "?mobile=1&redirect_uri=toonranks%3A%2F%2Fauth%2Fcallback&state=abc"
+    );
+
+    expect(request).toEqual({
+      isMobile: true,
+      redirectUri: "toonranks://auth/callback",
+      state: "abc",
+    });
+  });
+
+  it("rejects unknown redirect URIs", () => {
+    const request = getMobileAuthRequest(
+      "?mobile=1&redirect_uri=https%3A%2F%2Fevil.example%2Fcallback&state=abc"
+    );
+
+    expect(request.isMobile).toBe(false);
+    expect(request.redirectUri).toBe("https://evil.example/callback");
+  });
+
+  it("builds the signup verification callback", () => {
+    const url = buildMobileSignupVerificationRedirect({
+      isMobile: true,
+      redirectUri: "toonranks://auth/callback",
+      state: "abc",
+    });
+
+    expect(url).toBe(
+      "toonranks://auth/callback?error=email_verification_required&error_description=Please+verify+your+email%2C+then+log+in.&state=abc"
+    );
+  });
+
+  it("does not build signup callbacks for normal web requests", () => {
+    expect(
+      buildMobileSignupVerificationRedirect({
+        isMobile: false,
+        redirectUri: null,
+        state: null,
+      })
+    ).toBeNull();
+  });
+
+  it("redirects through location assign", () => {
+    const assign = vi.fn();
+    const originalLocation = window.location;
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { assign },
+    });
+
+    try {
+      redirectToMobileAuthCallback("toonranks://auth/callback?code=123");
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+
+    expect(assign).toHaveBeenCalledWith("toonranks://auth/callback?code=123");
+  });
+});

--- a/src/util/mobileAuthRedirect.ts
+++ b/src/util/mobileAuthRedirect.ts
@@ -1,0 +1,41 @@
+export const MOBILE_AUTH_CALLBACK_URL = "toonranks://auth/callback";
+
+export type MobileAuthRequest = {
+  isMobile: boolean;
+  redirectUri: string | null;
+  state: string | null;
+};
+
+export function getMobileAuthRequest(search: string): MobileAuthRequest {
+  const params = new URLSearchParams(search);
+  const redirectUri = params.get("redirect_uri");
+  const isMobile =
+    params.get("mobile") === "1" && redirectUri === MOBILE_AUTH_CALLBACK_URL;
+
+  return {
+    isMobile,
+    redirectUri,
+    state: params.get("state"),
+  };
+}
+
+export function buildMobileSignupVerificationRedirect(
+  request: MobileAuthRequest
+): string | null {
+  if (!request.isMobile || !request.redirectUri) return null;
+
+  const params = new URLSearchParams({
+    error: "email_verification_required",
+    error_description: "Please verify your email, then log in.",
+  });
+
+  if (request.state) {
+    params.set("state", request.state);
+  }
+
+  return `${request.redirectUri}?${params.toString()}`;
+}
+
+export function redirectToMobileAuthCallback(url: string): void {
+  window.location.assign(url);
+}


### PR DESCRIPTION
## Summary
- Add mobile auth redirect helpers and tests
- Create /auth/mobile-code from mobile login/signup flows
- Redirect explicit mobile auth requests back to toonranks://auth/callback
- Preserve normal website login, signup, and Google OAuth behavior

## Verification
- npm run test:run
- npm run lint
- npm run build
- git diff --check