### PR TITLE
Add forgot password flow to auth UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import Header from "./components/Header";
 import Home from "./pages/Home";
 import LoginPage from "./pages/LoginPage";
 import SignupPage from "./pages/SignupPage";
+import ForgotPasswordPage from "./pages/ForgotPasswordPage";
+import ResetPasswordPage from "./pages/ResetPasswordPage";
 import SeriesDetailPage from "./pages/SeriesDetailPage";
 import FilteredSeriesPage from "./pages/FilteredSeriesPage";
 import { SearchProvider } from "./components/SearchContext";
@@ -49,6 +51,11 @@ function App() {
                 <Route path="/" element={<Home />} />
                 <Route path="/login" element={<LoginPage />} />
                 <Route path="/signup" element={<SignupPage />} />
+                <Route
+                  path="/forgot-password"
+                  element={<ForgotPasswordPage />}
+                />
+                <Route path="/reset-password" element={<ResetPasswordPage />} />
                 <Route path="/series/:id" element={<SeriesDetailPage />} />
                 <Route path="/contact" element={<ContactPage />} />
                 <Route path="/verify-email" element={<VerifyEmailPage />} />

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -32,7 +32,9 @@ function isPublicAuthRoute(url?: string) {
     url.startsWith("/auth/signup") ||
     url.startsWith("/auth/verify-email") ||
     url.startsWith("/auth/google-oauth") ||
-    url.startsWith("/auth/resend-verification")
+    url.startsWith("/auth/resend-verification") ||
+    url.startsWith("/auth/forgot-password") ||
+    url.startsWith("/auth/reset-password")
   );
 }
 

--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -854,6 +854,44 @@ export const resendVerificationEmail = async (payload: {
   return res.data;
 };
 
+export const forgotPassword = async (payload: {
+  email: string;
+  captcha_token?: string;
+}): Promise<{ message: string }> => {
+  try {
+    const res = await api.post<{ message: string }>("/auth/forgot-password", {
+      email: payload.email.trim().toLowerCase(),
+      captcha_token: payload.captcha_token || undefined,
+    });
+    return res.data;
+  } catch (err: unknown) {
+    const detail = extractApiDetail(
+      err,
+      "Unable to send reset link. Please try again."
+    );
+    throw new Error(detail);
+  }
+};
+
+export const resetPassword = async (payload: {
+  token: string;
+  password: string;
+}): Promise<{ message: string }> => {
+  try {
+    const res = await api.post<{ message: string }>("/auth/reset-password", {
+      token: payload.token,
+      password: payload.password,
+    });
+    return res.data;
+  } catch (err: unknown) {
+    const detail = extractApiDetail(
+      err,
+      "Reset link is invalid or expired. Please request a new link."
+    );
+    throw new Error(detail);
+  }
+};
+
 export const uploadMyAvatar = async (file: File): Promise<UserAvatar> => {
   const form = new FormData();
   form.append("file", file);

--- a/src/components/PasswordField.test.tsx
+++ b/src/components/PasswordField.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import PasswordField from "./PasswordField";
+
+describe("PasswordField", () => {
+  it("toggles password visibility without changing the value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <PasswordField
+        value="secret-pass"
+        onChange={onChange}
+        placeholder="Password"
+        className="input"
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Password");
+    expect(input).toHaveAttribute("type", "password");
+
+    await user.click(screen.getByRole("button", { name: /show password/i }));
+    expect(input).toHaveAttribute("type", "text");
+    expect(input).toHaveValue("secret-pass");
+
+    await user.click(screen.getByRole("button", { name: /hide password/i }));
+    expect(input).toHaveAttribute("type", "password");
+  });
+});

--- a/src/components/PasswordField.tsx
+++ b/src/components/PasswordField.tsx
@@ -1,0 +1,44 @@
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+
+type PasswordFieldProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  className: string;
+  autoComplete?: string;
+};
+
+const PasswordField = ({
+  value,
+  onChange,
+  placeholder,
+  className,
+  autoComplete,
+}: PasswordFieldProps) => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className="relative">
+      <input
+        type={visible ? "text" : "password"}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoComplete={autoComplete}
+        className={`${className} pr-12`}
+      />
+      <button
+        type="button"
+        onClick={() => setVisible((next) => !next)}
+        aria-label={visible ? "Hide password" : "Show password"}
+        title={visible ? "Hide password" : "Show password"}
+        className="absolute right-3 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-full text-slate-500 transition hover:bg-slate-200/70 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-[#2a221c] dark:hover:text-slate-200"
+      >
+        {visible ? <EyeOff size={18} /> : <Eye size={18} />}
+      </button>
+    </div>
+  );
+};
+
+export default PasswordField;

--- a/src/pages/ForgotPasswordPage.tsx
+++ b/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,147 @@
+import { useRef, useState } from "react";
+import ReCAPTCHA from "react-google-recaptcha";
+import { Link } from "react-router-dom";
+import { forgotPassword } from "../api/manApi";
+import AuthShell from "../components/AuthShell";
+import { NoIndexSeo } from "../components/Seo";
+import { SITE_NAME } from "../config/site";
+
+const fieldClass =
+  "mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-300 focus:bg-white focus:ring-4 focus:ring-blue-100 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(22,18,15,0.98),_rgba(18,15,12,0.98))] dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-[#4a3c33] dark:focus:bg-[#181310] dark:focus:ring-[#2a221c]";
+
+const ForgotPasswordPage = () => {
+  const [email, setEmail] = useState("");
+  const [captchaToken, setCaptchaToken] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const recaptchaRef = useRef<ReCAPTCHA | null>(null);
+
+  const handleSubmit = async () => {
+    setError(null);
+    setMessage(null);
+
+    if (!email.trim()) {
+      setError("Email is required.");
+      return;
+    }
+
+    if (!captchaToken) {
+      setError("Please complete the CAPTCHA.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await forgotPassword({
+        email,
+        captcha_token: captchaToken,
+      });
+      setMessage(
+        response.message ||
+          "If an account exists for that email, a password reset link has been sent."
+      );
+    } catch {
+      setMessage(
+        "If an account exists for that email, a password reset link has been sent."
+      );
+    } finally {
+      setSubmitting(false);
+      setCaptchaToken("");
+      recaptchaRef.current?.reset();
+    }
+  };
+
+  return (
+    <AuthShell
+      eyebrow="Account Recovery"
+      title="Get back to your lists, ratings, and discussions."
+      description="Request a password reset link for your Toon Ranks account. We keep the response private so account details stay protected."
+      accentLabel="Reset link"
+      accentTitle="A short-lived link sent to your email."
+      accentBody="Use the link within 30 minutes to choose a new password. If you do not see it, check Spam and mark it as Not Spam."
+      highlights={["30-minute link", "Private response", "Email protected"]}
+      footerPrompt="Remembered your password?"
+      footerLinkLabel="Log in"
+      footerLinkTo="/login"
+    >
+      <NoIndexSeo title={`Forgot Password | ${SITE_NAME}`} />
+      <div>
+        <div className="mb-6">
+          <h2 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">
+            Forgot password
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+            Enter your account email and we'll send a reset link if an account
+            exists.
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-900/80 dark:bg-rose-950/40 dark:text-rose-200">
+            {error}
+          </div>
+        )}
+
+        {message && (
+          <div className="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm leading-6 text-emerald-700 dark:border-emerald-900/80 dark:bg-emerald-950/40 dark:text-emerald-200">
+            {message} Check your inbox and Spam folder. If it lands in Spam,
+            mark it as Not Spam.
+          </div>
+        )}
+
+        <label className="block">
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+            Email
+          </span>
+          <input
+            type="email"
+            placeholder="Email used at signup"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={fieldClass}
+          />
+        </label>
+
+        <div className="mt-5 overflow-x-auto rounded-2xl border border-slate-200 bg-slate-50/70 px-3 py-3 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(25,21,18,0.96),_rgba(20,17,14,0.96))]">
+          <ReCAPTCHA
+            ref={recaptchaRef}
+            sitekey={import.meta.env.VITE_RECAPTCHA_SITE_KEY}
+            onChange={(token) => setCaptchaToken(token || "")}
+            onExpired={() => {
+              setCaptchaToken("");
+              setError("CAPTCHA expired. Please try again.");
+            }}
+            onError={() => {
+              setCaptchaToken("");
+              setError("CAPTCHA failed to load. Please retry.");
+            }}
+          />
+        </div>
+
+        <button
+          onClick={handleSubmit}
+          disabled={submitting}
+          className={`mt-5 w-full rounded-2xl px-4 py-3 text-sm font-semibold text-white transition ${
+            submitting
+              ? "cursor-not-allowed bg-blue-400"
+              : "bg-blue-600 hover:bg-blue-700"
+          }`}
+        >
+          {submitting ? "Sending link..." : "Send reset link"}
+        </button>
+
+        <p className="mt-4 text-center text-sm text-slate-500 dark:text-slate-400">
+          <Link
+            to="/signup"
+            className="font-semibold text-blue-600 transition hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            Need a new account?
+          </Link>
+        </p>
+      </div>
+    </AuthShell>
+  );
+};
+
+export default ForgotPasswordPage;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -9,6 +9,7 @@ import {
 import type { AuthResponse } from "../api/manApi";
 import GoogleOAuthButton from "../components/GoogleOAuthButton";
 import AuthShell from "../components/AuthShell";
+import PasswordField from "../components/PasswordField";
 import { scheduleLogoutAtJwtExp } from "../util/authUtils";
 import { useUser } from "../login/useUser";
 import { NoIndexSeo } from "../components/Seo";
@@ -188,18 +189,18 @@ const LoginPage = () => {
                 Password
               </span>
               <Link
-                to="/signup"
+                to="/forgot-password"
                 className="text-xs font-medium text-slate-500 transition hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200"
               >
-                Need an account?
+                Forgot password?
               </Link>
             </div>
-            <input
-              type="password"
+            <PasswordField
               placeholder="Enter your password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={setPassword}
               className={fieldClass}
+              autoComplete="current-password"
             />
           </label>
         </div>

--- a/src/pages/ResetPasswordPage.tsx
+++ b/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { resetPassword } from "../api/manApi";
+import AuthShell from "../components/AuthShell";
+import PasswordField from "../components/PasswordField";
+import { NoIndexSeo } from "../components/Seo";
+import { SITE_NAME } from "../config/site";
+
+const fieldClass =
+  "mt-2 w-full rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm text-slate-800 outline-none transition placeholder:text-slate-400 focus:border-blue-300 focus:bg-white focus:ring-4 focus:ring-blue-100 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(22,18,15,0.98),_rgba(18,15,12,0.98))] dark:text-slate-100 dark:placeholder:text-slate-500 dark:focus:border-[#4a3c33] dark:focus:bg-[#181310] dark:focus:ring-[#2a221c]";
+
+const ResetPasswordPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get("token") || "";
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    setError(null);
+    setMessage(null);
+
+    if (!token) {
+      setError("Missing reset token. Please request a new password reset link.");
+      return;
+    }
+
+    if (password.trim().length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const response = await resetPassword({ token, password });
+      setMessage(response.message || "Password reset successful.");
+      setTimeout(() => navigate("/login"), 2000);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Reset link is invalid or expired. Please request a new link."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <AuthShell
+      eyebrow="New Password"
+      title="Choose a fresh password for your Toon Ranks account."
+      description="Reset links expire quickly. If this one no longer works, request another from the login page."
+      accentLabel="Account security"
+      accentTitle="One reset link, one password change."
+      accentBody="After your password changes, the reset link cannot be reused. Log in with the new password to continue."
+      highlights={["8+ characters", "Single-use link", "Back to login"]}
+      footerPrompt="Already reset it?"
+      footerLinkLabel="Log in"
+      footerLinkTo="/login"
+    >
+      <NoIndexSeo title={`Reset Password | ${SITE_NAME}`} />
+      <div>
+        <div className="mb-6">
+          <h2 className="text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">
+            Reset password
+          </h2>
+          <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+            Enter a new password for your account.
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700 dark:border-rose-900/80 dark:bg-rose-950/40 dark:text-rose-200">
+            {error}
+          </div>
+        )}
+
+        {message && (
+          <div className="mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700 dark:border-emerald-900/80 dark:bg-emerald-950/40 dark:text-emerald-200">
+            {message} Redirecting to login...
+          </div>
+        )}
+
+        {!token && (
+          <div className="mb-4 rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm leading-6 text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/30 dark:text-amber-200">
+            This reset link is missing a token. Request a new reset email from
+            the login page.
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <label className="block">
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              New password
+            </span>
+            <PasswordField
+              value={password}
+              onChange={setPassword}
+              placeholder="Enter a new password"
+              className={fieldClass}
+              autoComplete="new-password"
+            />
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+              Confirm password
+            </span>
+            <PasswordField
+              value={confirmPassword}
+              onChange={setConfirmPassword}
+              placeholder="Confirm your new password"
+              className={fieldClass}
+              autoComplete="new-password"
+            />
+          </label>
+        </div>
+
+        <button
+          onClick={handleSubmit}
+          disabled={submitting || !token}
+          className={`mt-5 w-full rounded-2xl px-4 py-3 text-sm font-semibold text-white transition ${
+            submitting || !token
+              ? "cursor-not-allowed bg-blue-400"
+              : "bg-blue-600 hover:bg-blue-700"
+          }`}
+        >
+          {submitting ? "Updating password..." : "Reset password"}
+        </button>
+
+        <p className="mt-4 text-center text-sm text-slate-500 dark:text-slate-400">
+          <Link
+            to="/forgot-password"
+            className="font-semibold text-blue-600 transition hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            Request a new reset link
+          </Link>
+        </p>
+      </div>
+    </AuthShell>
+  );
+};
+
+export default ResetPasswordPage;

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -5,6 +5,7 @@ import { createMobileAuthCode, signup } from "../api/manApi";
 import type { AuthResponse } from "../api/manApi";
 import GoogleOAuthButton from "../components/GoogleOAuthButton";
 import AuthShell from "../components/AuthShell";
+import PasswordField from "../components/PasswordField";
 import { NoIndexSeo } from "../components/Seo";
 import { SITE_NAME } from "../config/site";
 import { useUser } from "../login/useUser";
@@ -196,12 +197,12 @@ const SignupPage = () => {
                 Already registered?
               </Link>
             </div>
-            <input
-              type="password"
+            <PasswordField
               placeholder="Create a password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={setPassword}
               className={fieldClass}
+              autoComplete="new-password"
             />
           </label>
         </div>


### PR DESCRIPTION
## Summary
- Add forgot password and reset password pages wired to the backend auth endpoints
- Add reusable password visibility toggle control
- Use the password visibility control on login, signup, and reset password forms
- Treat forgot/reset password endpoints as public auth routes in the Axios client
- Add a focused test for password visibility toggling