### PR TITLE
repo name change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "man-review",
+  "name": "toonranks-frontend",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "man-review",
+      "name": "toonranks-frontend",
       "version": "0.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "man-review",
+  "name": "toonranks-frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- Rename the frontend npm package from `man-review` to `toonranks-frontend`
- Update package-lock metadata to match

## Notes
- Deployment URLs, local folder paths, GitHub repo names, and database schema names are intentionally unchanged in this pass.

## Verification
- npm run build