### PR TITLE
Document Toon Ranks frontend email aliases

### DIFF
--- a/docs/EMAIL_ALIASES.md
+++ b/docs/EMAIL_ALIASES.md
@@ -1,0 +1,22 @@
+# Toon Ranks Email Aliases
+
+The public website should keep `Toon Ranks` as the product brand and use `support@toonranks.com` for user-facing contact links. Other aliases exist for backend/system workflows and future product areas.
+
+## Alias Map
+
+| Purpose | Alias | Frontend usage |
+| --- | --- | --- |
+| Human support/contact | `support@toonranks.com` | Contact page, Terms, Privacy, and public support metadata. |
+| Signup verification | `noreply@toonranks.com` | Backend sender for verification emails. Do not use as a public contact link. |
+| Password reset | `accounts@toonranks.com` | Backend sender for password reset emails. Do not use as a public contact link. |
+| Billing/subscription | `billing@toonranks.com` | Reserved for future subscription and billing UI. |
+| Internal/admin alerts | `admin@toonranks.com` | Reserved for internal notifications. Do not expose as public support. |
+
+## Implementation Notes
+
+Shared constants live in `src/config/site.ts`.
+
+- Use `CONTACT_EMAIL` or `SUPPORT_EMAIL` for public pages.
+- Use `BILLING_EMAIL` only when a billing/subscription UI exists.
+- Do not display `VERIFICATION_EMAIL`, `PASSWORD_RESET_EMAIL`, or `ADMIN_EMAIL` as general user support addresses.
+- Avoid committing SMTP credentials, email app passwords, or secret manager values to this repository.

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,7 +1,14 @@
 export const SITE_ORIGIN = "https://www.toonranks.com";
 export const SITE_NAME = "Toon Ranks";
 export const OPERATOR_NAME = "Nofara LLC";
-export const CONTACT_EMAIL = "support@toonranks.com";
+
+export const SUPPORT_EMAIL = "support@toonranks.com";
+export const VERIFICATION_EMAIL = "noreply@toonranks.com";
+export const PASSWORD_RESET_EMAIL = "accounts@toonranks.com";
+export const BILLING_EMAIL = "billing@toonranks.com";
+export const ADMIN_EMAIL = "admin@toonranks.com";
+
+export const CONTACT_EMAIL = SUPPORT_EMAIL;
 export const DEFAULT_SOCIAL_IMAGE = `${SITE_ORIGIN}/android-chrome-512x512.png`;
 
 export const absoluteUrl = (path = "/") =>


### PR DESCRIPTION
## Summary
- Add shared frontend constants for Toon Ranks email aliases
- Keep public contact/legal surfaces using support@toonranks.com
- Document which aliases are public, backend-only, or reserved for future billing/admin flows

## Verification
- npm run lint
- npm test -- --run
- npm run build