### PR TITLE
add View thread link to reply and vote cards on the account forum act…

### DIFF
--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -466,6 +466,7 @@ export type ForumThread = {
 };
 export type ForumPost = {
   id: number;
+  thread_id?: number;
   author_username?: string | null;
   author_role?: UserRole | null;
   author_avatar_url?: string | null;

--- a/src/components/ForumActivitySection.tsx
+++ b/src/components/ForumActivitySection.tsx
@@ -278,9 +278,19 @@ export function ForumActivitySection() {
                   ))}
                 </div>
               )}
-              <p className="text-xs text-slate-400 dark:text-slate-500">
-                {shortDate(p.created_at)}
-              </p>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs text-slate-400 dark:text-slate-500">
+                  {shortDate(p.created_at)}
+                </p>
+                {p.thread_id ? (
+                  <Link
+                    to={`/forum/${p.thread_id}`}
+                    className="text-xs font-medium text-slate-500 hover:text-slate-800 hover:underline dark:text-slate-400 dark:hover:text-slate-200"
+                  >
+                    View thread →
+                  </Link>
+                ) : null}
+              </div>
             </div>
           ))}
           {postsData && (
@@ -325,9 +335,19 @@ export function ForumActivitySection() {
                   </span>
                 ) : null}
               </div>
-              <p className="text-xs text-slate-400 dark:text-slate-500">
-                {shortDate(p.created_at)}
-              </p>
+              <div className="flex items-center justify-between gap-3">
+                <p className="text-xs text-slate-400 dark:text-slate-500">
+                  {shortDate(p.created_at)}
+                </p>
+                {p.thread_id ? (
+                  <Link
+                    to={`/forum/${p.thread_id}`}
+                    className="text-xs font-medium text-slate-500 hover:text-slate-800 hover:underline dark:text-slate-400 dark:hover:text-slate-200"
+                  >
+                    View thread →
+                  </Link>
+                ) : null}
+              </div>
             </div>
           ))}
           {votesData && (


### PR DESCRIPTION
Now that thread_id is exposed in ForumPostOut, wire up deep-links from the account page forum activity section.

Changes:
- manApi.ts — added thread_id?: number to the ForumPost type
- ForumActivitySection.tsx — reply and vote cards each show a "View thread →" link that navigates to /forum/{thread_id}

All 21 frontend tests pass.