### PR TITLE
scroll to specific reply when opening a thread from account forum act…

### DIFF
--- a/src/components/ForumActivitySection.tsx
+++ b/src/components/ForumActivitySection.tsx
@@ -284,7 +284,7 @@ export function ForumActivitySection() {
                 </p>
                 {p.thread_id ? (
                   <Link
-                    to={`/forum/${p.thread_id}`}
+                    to={`/forum/${p.thread_id}#post-${p.id}`}
                     className="text-xs font-medium text-slate-500 hover:text-slate-800 hover:underline dark:text-slate-400 dark:hover:text-slate-200"
                   >
                     View thread →
@@ -341,7 +341,7 @@ export function ForumActivitySection() {
                 </p>
                 {p.thread_id ? (
                   <Link
-                    to={`/forum/${p.thread_id}`}
+                    to={`/forum/${p.thread_id}#post-${p.id}`}
                     className="text-xs font-medium text-slate-500 hover:text-slate-800 hover:underline dark:text-slate-400 dark:hover:text-slate-200"
                   >
                     View thread →

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -646,6 +646,19 @@ export default function ThreadPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId, page]);
 
+  // Scroll to a specific post when the URL contains a #post-{id} hash.
+  // Fires after posts finish loading so the target element is in the DOM.
+  useEffect(() => {
+    if (!posts.length || !loc.hash.startsWith("#post-")) return;
+    const el = document.getElementById(loc.hash.slice(1));
+    if (!el) return;
+    const timer = setTimeout(
+      () => el.scrollIntoView({ behavior: "smooth", block: "start" }),
+      80
+    );
+    return () => clearTimeout(timer);
+  }, [posts, loc.hash]);
+
   // Called by ReplyBranch → enters edit mode for a specific post
   const handleBeginEdit = (postId: number, content: string) => {
     setEditPostId(postId);
@@ -1471,6 +1484,7 @@ function ReplyBranch({
   return (
     <div className="space-y-2">
       <article
+        id={`post-${post.id}`}
         className={
           (isTopLevel
             ? "rounded-[24px] border border-slate-200/80 bg-white px-4 py-4 shadow-[0_14px_30px_rgba(15,23,42,0.06)] dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(27,22,19,0.96),_rgba(21,17,14,0.96))] dark:shadow-[0_14px_30px_rgba(0,0,0,0.5)] sm:px-5 sm:py-5"


### PR DESCRIPTION
Clicking "View thread →" on a reply or vote row now scrolls the page directly to that post.

Changes:
- ThreadPage.tsx — added id="post-{id}" to every post's article element; added a useEffect that reads loc.hash after posts load and calls scrollIntoView on the target element
- ForumActivitySection.tsx — updated both the replies tab and votes tab "View thread →" links to include the #post-{id} hash fragment

Note: scroll works for posts on the currently loaded page. If the reply is on a later pagination page the user will still land on the correct thread at the top — no regression from current behavior.

All 21 frontend tests pass.