### PR TITLE
feat(forum): edited indicator, char counter, quote-reply, draft auto-…

### DIFF
--- a/FORUM_IMPROVEMENTS_TODO.md
+++ b/FORUM_IMPROVEMENTS_TODO.md
@@ -44,9 +44,11 @@ of popular modern forums (Reddit, Discourse, phpBB). The backend companion doc i
 
 ---
 
-## Phase 1: Quick Wins — Frontend-Only Changes (No Backend Work Required)
+## ✅ Phase 1: Quick Wins — Frontend-Only Changes (No Backend Work Required)
 
-Suggested branch: `frontend-forum-quick-wins`
+Suggested branch: `frontend-forum-quick-wins` — **complete, pending merge**
+
+No migration required.
 
 These changes require no backend work. All the data needed already exists in API responses.
 
@@ -58,111 +60,31 @@ Every `ForumPostOut` already includes `created_at` and `updated_at`. The post co
 displays `updated_at`. An "(edited)" label should appear whenever `updated_at` is meaningfully
 later than `created_at` (allow a 10-second buffer to account for flush timing).
 
-- [ ] Create a utility function (inline or in a shared `src/utils/dateUtils.ts`):
-  ```typescript
-  export function wasEdited(createdAt: string, updatedAt: string): boolean {
-    const diff = new Date(updatedAt).getTime() - new Date(createdAt).getTime();
-    return diff > 10_000; // more than 10 seconds later
-  }
-  ```
-- [ ] In the post/reply render section of `ThreadPage.tsx`, add the edited label next to the
-  post timestamp:
-  ```tsx
-  {wasEdited(post.created_at, post.updated_at) && (
-    <span className="text-xs text-muted-foreground italic ml-2">(edited)</span>
-  )}
-  ```
-  Place it immediately after the `created_at` timestamp display in the post byline row.
-- [ ] Apply the same check to the original post (the first post / OP) at the top of the thread.
+- [x] Created `src/util/dateUtils.ts` with `wasEdited(createdAt, updatedAt): boolean` (10-second buffer)
+- [x] `(edited)` label added after timestamp in `ReplyBranch` byline
+- [x] `(edited)` label added after timestamp in the OP (posts[0]) byline
 
 ### 1b — Character limit counter in the web reply composer
 
-**File:** `src/pages/ThreadPage.tsx` — `RichReplyEditor` component (or wherever the reply
-`<textarea>` lives)
-
-The web composer has no visible character count. The backend `CreatePostIn` schema enforces a
-content length limit (check `app/schemas/forum_schemas.py` for the exact `max_length` — it is
-likely 10,000 characters based on the `Text` column type; confirm and match it). The mobile app
-already shows a counter.
-
-- [ ] Identify the maximum allowed content length from `app/schemas/forum_schemas.py`
-  `content_markdown` field validator and store it as a constant:
-  ```typescript
-  const MAX_POST_LENGTH = 10_000; // match backend validator exactly
-  ```
-- [ ] Add a live character counter below the reply `<textarea>`:
-  ```tsx
-  <div className="flex justify-end text-xs text-muted-foreground mt-1">
-    <span className={content.length > MAX_POST_LENGTH ? "text-red-500" : ""}>
-      {content.length} / {MAX_POST_LENGTH}
-    </span>
-  </div>
-  ```
-  Color turns red when the limit is reached or exceeded. Disable the submit button when
-  `content.length > MAX_POST_LENGTH`.
-- [ ] Apply the same counter to the thread creation modal's "First post" textarea.
+- [x] `MAX_POST_LENGTH = 10_000` constant added to `RichReplyEditor.tsx`
+- [x] Live character counter displayed below textarea; turns red when limit exceeded
+- [x] Submit button disabled when `value.length > MAX_POST_LENGTH`
+- [x] Over-limit guard in `handlePrimary` with a notice modal error
 
 ### 1c — Quote-reply button
 
-**File:** `src/pages/ThreadPage.tsx`
-
-A one-click "Quote" button on each post that pre-fills the reply composer with a markdown
-blockquote of the post content. This does not require any backend change.
-
-- [ ] Add a "Quote" button to the post action row (alongside the existing upvote/downvote controls).
-  Show it only on posts in unlocked threads.
-- [ ] On click, insert a quoted block into the reply composer:
-  ```typescript
-  function handleQuoteReply(post: ForumPost) {
-    const quoted = post.content_markdown
-      .split("\n")
-      .map((line) => `> ${line}`)
-      .join("\n");
-    const attribution = `> **@${post.author_username}** wrote:\n${quoted}\n\n`;
-    setReplyContent((prev) => prev ? `${attribution}\n${prev}` : attribution);
-    // scroll to and focus the reply composer
-    replyEditorRef.current?.focus();
-  }
-  ```
-- [ ] If the thread is viewing a nested reply, set `replyParentId` to that post's id so the quoted
-  reply is threaded under the correct parent.
-- [ ] Add a ref (`replyEditorRef`) to the reply `<textarea>` so the quote action can auto-focus it.
+- [x] "Quote" button added to `ReplyBranch` action row; shown only on unlocked threads
+- [x] `handleQuote` in `ThreadPage` builds blockquote markdown with `> **@author** wrote:` attribution
+- [x] Bottom editor remounts with quoted content via `key={quoteKey}` + `initial={quoteInitial}`
+- [x] `quoteParentId` wired into `createForumPost` so quoted replies thread under the quoted post
+- [x] Bottom editor section scrolled into view on quote (`bottomEditorRef`)
+- [x] `onQuote` prop propagated down the full `ReplyBranch` tree
 
 ### 1d — Draft auto-save
 
-**File:** `src/pages/ThreadPage.tsx` (reply composer), `src/pages/ForumPage.tsx` (thread creation modal)
-
-When a user types a long reply and accidentally navigates away, the draft is lost. Save drafts to
-`localStorage` keyed by thread ID.
-
-- [ ] In the reply composer, use a `useEffect` to save the draft to localStorage on content change
-  (debounce 1 second to avoid excessive writes):
-  ```typescript
-  const DRAFT_KEY = `forum_draft_thread_${threadId}`;
-
-  // On mount: restore saved draft
-  useEffect(() => {
-    const saved = localStorage.getItem(DRAFT_KEY);
-    if (saved) setReplyContent(saved);
-  }, [threadId]);
-
-  // On change: save draft (debounced)
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      if (replyContent.trim()) {
-        localStorage.setItem(DRAFT_KEY, replyContent);
-      } else {
-        localStorage.removeItem(DRAFT_KEY);
-      }
-    }, 1000);
-    return () => clearTimeout(timer);
-  }, [replyContent, threadId]);
-  ```
-- [ ] Clear the draft from localStorage after a successful post submission.
-- [ ] Show a subtle "Draft saved" indicator in the composer after the draft is persisted (optional,
-  small muted text below the character counter).
-- [ ] Apply the same pattern to the thread creation modal in `ForumPage.tsx`, keyed as
-  `forum_draft_new_thread`.
+- [x] `RichReplyEditor.tsx`: draft saved to `localStorage` keyed as `forum_draft_thread_${threadId}` (reply mode only); debounced 1 s; restored on mount; cleared on successful post
+- [x] "Draft saved" indicator shows briefly after each save
+- [x] `NewThreadModal` in `ForumPage.tsx`: title + body saved to `forum_draft_new_thread` (create mode only); debounced 1 s; restored on mount; cleared on successful create
 
 ---
 

--- a/src/components/RichReplyEditor.tsx
+++ b/src/components/RichReplyEditor.tsx
@@ -47,6 +47,34 @@ export default function RichReplyEditor({
 
   const notice = useNotice();
   const MAX_MENTIONS = 10;
+  const MAX_POST_LENGTH = 10_000;
+
+  // ── Draft auto-save (reply mode only) ─────────────────────────────────────
+  const draftKey = mode === "reply" ? `forum_draft_thread_${threadId}` : null;
+  const [draftSaved, setDraftSaved] = useState(false);
+
+  // Restore draft on first mount (reply mode only)
+  useEffect(() => {
+    if (!draftKey) return;
+    const saved = localStorage.getItem(draftKey);
+    if (saved) setValue(saved);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftKey]);
+
+  // Save draft on change (debounced 1 s)
+  useEffect(() => {
+    if (!draftKey) return;
+    const timer = setTimeout(() => {
+      if (value.trim()) {
+        localStorage.setItem(draftKey, value);
+        setDraftSaved(true);
+        setTimeout(() => setDraftSaved(false), 2000);
+      } else {
+        localStorage.removeItem(draftKey);
+      }
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [value, draftKey]);
 
   const toolbarButtonClass =
     "rounded border border-slate-200 px-2 py-1 text-slate-700 hover:bg-gray-50 dark:border-[#3a3028] dark:text-slate-200 dark:hover:bg-[#241d19]";
@@ -236,6 +264,14 @@ export default function RichReplyEditor({
       });
       return;
     }
+    if (value.length > MAX_POST_LENGTH) {
+      notice.show({
+        message: `Reply is too long (${value.length.toLocaleString()} / ${MAX_POST_LENGTH.toLocaleString()} characters).`,
+        title: "Too long",
+        variant: "warning",
+      });
+      return;
+    }
     const ids = Array.from(new Set(extractIds(trimmed)));
 
     if (mode === "reply") {
@@ -264,6 +300,8 @@ export default function RichReplyEditor({
         setResults([]);
         setMenuOpen(false);
         setMentionStart(null);
+        // Clear draft on successful post
+        if (draftKey) localStorage.removeItem(draftKey);
       }
     } catch (err: unknown) {
       alert(
@@ -469,6 +507,23 @@ export default function RichReplyEditor({
         }
         className="h-28 w-full rounded border border-slate-200 bg-white px-3 py-2 text-slate-800 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(22,18,15,0.98),_rgba(18,15,12,0.98))] dark:text-slate-100"
       />
+      <div className="flex items-center justify-between mt-1">
+        {draftSaved && (
+          <span className="text-[11px] text-slate-400 dark:text-slate-500 italic">
+            Draft saved
+          </span>
+        )}
+        {!draftSaved && <span />}
+        <span
+          className={`text-xs ${
+            value.length > MAX_POST_LENGTH
+              ? "text-red-500 font-medium"
+              : "text-slate-400 dark:text-slate-500"
+          }`}
+        >
+          {value.length.toLocaleString()} / {MAX_POST_LENGTH.toLocaleString()}
+        </span>
+      </div>
 
       {menuOpen && results.length > 0 && (
         <div
@@ -539,7 +594,8 @@ export default function RichReplyEditor({
             </button>
             <button
               onClick={handlePrimary}
-              className="rounded bg-blue-600 px-3 py-1.5 text-white dark:bg-[linear-gradient(145deg,_rgba(51,93,195,0.96),_rgba(34,73,170,0.96))] dark:hover:bg-[linear-gradient(145deg,_rgba(69,109,209,0.96),_rgba(48,86,184,0.96))]"
+              disabled={value.length > MAX_POST_LENGTH}
+              className="rounded bg-blue-600 px-3 py-1.5 text-white disabled:opacity-50 dark:bg-[linear-gradient(145deg,_rgba(51,93,195,0.96),_rgba(34,73,170,0.96))] dark:hover:bg-[linear-gradient(145deg,_rgba(69,109,209,0.96),_rgba(48,86,184,0.96))]"
             >
               Save
             </button>
@@ -547,7 +603,8 @@ export default function RichReplyEditor({
         ) : (
           <button
             onClick={handlePrimary}
-            className="rounded bg-blue-600 px-3 py-1.5 text-white dark:bg-[linear-gradient(145deg,_rgba(51,93,195,0.96),_rgba(34,73,170,0.96))] dark:hover:bg-[linear-gradient(145deg,_rgba(69,109,209,0.96),_rgba(48,86,184,0.96))]"
+            disabled={value.length > MAX_POST_LENGTH}
+            className="rounded bg-blue-600 px-3 py-1.5 text-white disabled:opacity-50 dark:bg-[linear-gradient(145deg,_rgba(51,93,195,0.96),_rgba(34,73,170,0.96))] dark:hover:bg-[linear-gradient(145deg,_rgba(69,109,209,0.96),_rgba(48,86,184,0.96))]"
           >
             Post Reply
           </button>

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -709,8 +709,37 @@ function NewThreadModal({
   const { user } = useUser();
   const notice = useNotice();
 
-  const [title, setTitle] = useState(initialTitle);
-  const [md, setMd] = useState(initialMd);
+  const THREAD_DRAFT_KEY = "forum_draft_new_thread";
+
+  const [title, setTitle] = useState(() => {
+    if (mode === "create") {
+      return localStorage.getItem(THREAD_DRAFT_KEY)
+        ? (JSON.parse(localStorage.getItem(THREAD_DRAFT_KEY)!) as { title?: string }).title ?? initialTitle
+        : initialTitle;
+    }
+    return initialTitle;
+  });
+  const [md, setMd] = useState(() => {
+    if (mode === "create") {
+      return localStorage.getItem(THREAD_DRAFT_KEY)
+        ? (JSON.parse(localStorage.getItem(THREAD_DRAFT_KEY)!) as { md?: string }).md ?? initialMd
+        : initialMd;
+    }
+    return initialMd;
+  });
+
+  // Save draft (debounced 1 s) — create mode only
+  useEffect(() => {
+    if (mode !== "create") return;
+    const timer = setTimeout(() => {
+      if (title.trim() || md.trim()) {
+        localStorage.setItem(THREAD_DRAFT_KEY, JSON.stringify({ title, md }));
+      } else {
+        localStorage.removeItem(THREAD_DRAFT_KEY);
+      }
+    }, 1000);
+    return () => clearTimeout(timer);
+  }, [title, md, mode]);
 
   // existing series picker state
   const [query, setQuery] = useState("");
@@ -946,6 +975,7 @@ function NewThreadModal({
         first_post_markdown: md,
         series_ids,
       });
+      localStorage.removeItem(THREAD_DRAFT_KEY);
       onCreated?.(t);
     } catch (e: unknown) {
       let msg = "Failed to create thread.";

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type CSSProperties } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 import {
   useParams,
   Link,
@@ -37,6 +37,7 @@ import UserAvatar from "../components/UserAvatar";
 import { RankerBadge } from "../components/RankerBadge";
 import { inlineUsernameClassName } from "../util/userDisplay";
 import { getTopRankMap } from "../util/rankMap";
+import { wasEdited } from "../util/dateUtils";
 import {
   DEFAULT_SOCIAL_IMAGE,
   SITE_NAME,
@@ -518,6 +519,26 @@ export default function ThreadPage() {
   const notice = useNotice();
   const [rankMap, setRankMap] = useState<Record<string, number>>({});
 
+  // ── Quote-reply state ────────────────────────────────────────────────────
+  const [quoteKey, setQuoteKey] = useState(0);
+  const [quoteInitial, setQuoteInitial] = useState("");
+  const [quoteParentId, setQuoteParentId] = useState<number | null>(null);
+  const bottomEditorRef = useRef<HTMLDivElement | null>(null);
+
+  const handleQuote = (post: ForumPost) => {
+    const quoted = post.content_markdown
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n");
+    const attribution = `> **@${post.author_username ?? "?"}** wrote:\n${quoted}\n\n`;
+    setQuoteInitial(attribution);
+    setQuoteParentId(post.id);
+    setQuoteKey((k) => k + 1);
+    setTimeout(() => {
+      bottomEditorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
   const loc = useLocation();
   const siteUrl = SITE_ORIGIN;
 
@@ -947,6 +968,9 @@ export default function ThreadPage() {
                       )}
                     </span>
                     <span>{new Date(posts[0].created_at).toLocaleString()}</span>
+                    {wasEdited(posts[0].created_at, posts[0].updated_at) && (
+                      <span className="text-xs italic text-slate-400 dark:text-slate-500">(edited)</span>
+                    )}
                   </div>
 
                   <div className="max-w-3xl space-y-2">
@@ -1113,6 +1137,7 @@ export default function ThreadPage() {
                         onPostCreated={(post) =>
                           setPosts((prev) => [...prev, post])
                         }
+                        onQuote={handleQuote}
                         notify={notice.show}
                         rankMap={rankMap}
                       />
@@ -1222,6 +1247,7 @@ export default function ThreadPage() {
                   onPostCreated={(post) =>
                     setPosts((prev) => [...prev, post])
                   }
+                  onQuote={handleQuote}
                   notify={notice.show}
                   rankMap={rankMap}
                 />
@@ -1238,7 +1264,7 @@ export default function ThreadPage() {
         </div>
       )}
 
-      <div className="mt-6 overflow-hidden rounded-[28px] border border-slate-200/80 bg-white shadow-[0_18px_40px_rgba(15,23,42,0.07)] dark:border-[#322922] dark:bg-[#1b1613] dark:shadow-[0_18px_40px_rgba(0,0,0,0.55)]">
+      <div ref={bottomEditorRef} className="mt-6 overflow-hidden rounded-[28px] border border-slate-200/80 bg-white shadow-[0_18px_40px_rgba(15,23,42,0.07)] dark:border-[#322922] dark:bg-[#1b1613] dark:shadow-[0_18px_40px_rgba(0,0,0,0.55)]">
         <div className="border-b border-slate-200/70 bg-[linear-gradient(135deg,rgba(248,250,252,0.94),rgba(255,255,255,0.98)_62%,rgba(239,246,255,0.8))] px-5 py-4 dark:border-[#322922] dark:bg-[linear-gradient(135deg,rgba(34,27,23,0.98),rgba(24,19,16,0.98)_62%,rgba(29,22,18,0.9))] sm:px-6">
           <div className="space-y-1">
             <h3 className="text-lg font-semibold tracking-tight text-slate-900 dark:text-white">
@@ -1255,8 +1281,10 @@ export default function ThreadPage() {
         <div className="px-5 py-5 sm:px-6 sm:py-6">
           {!thread?.locked || isAdmin ? (
             <RichReplyEditor
+              key={quoteKey}
               compact={false}
               threadId={threadId}
+              initial={quoteInitial}
               onSubmit={async (content, seriesIds) => {
                 if (!user) {
                   notice.show({
@@ -1264,7 +1292,6 @@ export default function ThreadPage() {
                     title: "Sign in required",
                     variant: "warning",
                   });
-
                   return;
                 }
                 const trimmed = content.trim();
@@ -1274,15 +1301,17 @@ export default function ThreadPage() {
                     title: "Cannot post",
                     variant: "warning",
                   });
-
                   return;
                 }
                 try {
                   const p = await createForumPost(threadId, {
                     content_markdown: trimmed,
                     series_ids: seriesIds,
+                    parent_id: quoteParentId ?? undefined,
                   });
                   setPosts((prev) => [...prev, p]);
+                  setQuoteInitial("");
+                  setQuoteParentId(null);
                 } catch (err: unknown) {
                   notice.show({
                     message: getErrorMessage(err) || "Failed to post reply.",
@@ -1388,6 +1417,7 @@ function ReplyBranch({
   onSaveEdit,
   onCancelEdit,
   onPostCreated,
+  onQuote,
   notify,
   rankMap,
 }: {
@@ -1410,6 +1440,7 @@ function ReplyBranch({
   onSaveEdit: (content: string, seriesIds: number[]) => Promise<void> | void;
   onCancelEdit: () => void;
   onPostCreated: (post: ForumPost) => void;
+  onQuote?: (post: ForumPost) => void;
   notify: (opts: {
     title?: string;
     message: string | React.ReactNode;
@@ -1587,9 +1618,21 @@ function ReplyBranch({
               )}
             </span>
             <span>{new Date(post.created_at).toLocaleString()}</span>
+            {wasEdited(post.created_at, post.updated_at) && (
+              <span className="text-xs italic text-slate-400 dark:text-slate-500">(edited)</span>
+            )}
           </div>
 
           <div className="flex items-center gap-2 self-start">
+            {!locked && onQuote && (
+              <button
+                onClick={() => onQuote(post)}
+                className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-500 transition hover:border-slate-300 hover:bg-slate-50 dark:border-[#3a3028] dark:text-slate-400 dark:hover:bg-[#241d19]"
+                title="Quote this post in your reply"
+              >
+                Quote
+              </button>
+            )}
             {canModify && !isEditingThis && (
               <div className="flex items-center gap-2">
                 <button
@@ -1765,6 +1808,7 @@ function ReplyBranch({
           onSaveEdit={onSaveEdit}
           onCancelEdit={onCancelEdit}
           onPostCreated={onPostCreated}
+          onQuote={onQuote}
           notify={notify}
           rankMap={rankMap}
         />

--- a/src/util/dateUtils.ts
+++ b/src/util/dateUtils.ts
@@ -1,0 +1,8 @@
+/**
+ * Returns true when a post's updatedAt is meaningfully later than createdAt.
+ * A 10-second buffer covers server-side flush timing differences.
+ */
+export function wasEdited(createdAt: string, updatedAt: string): boolean {
+  const diff = new Date(updatedAt).getTime() - new Date(createdAt).getTime();
+  return diff > 10_000;
+}


### PR DESCRIPTION
Frontend-only quick wins — no backend changes required.

- (edited) label on posts where updated_at > created_at + 10s (OP + all replies)
- Character counter in RichReplyEditor (MAX 10,000); turns red + disables submit when exceeded
- Quote button on each post — pre-fills bottom editor with blockquote + attribution, threads under quoted post, scrolls into view
- Draft auto-save: reply drafts saved to localStorage per thread (debounced 1s, cleared on post); new thread drafts saved to forum_draft_new_thread key