### PR TITLE
feat(forum): markdown formatting toolbar — bold, italic, link, code, …

### DIFF
--- a/FORUM_IMPROVEMENTS_TODO.md
+++ b/FORUM_IMPROVEMENTS_TODO.md
@@ -107,50 +107,16 @@ Suggested branch: `frontend-forum-sorting` — **complete, pending merge**
 
 ---
 
-## Phase 3: Rich Text Markdown Toolbar
+## ✅ Phase 3: Rich Text Markdown Toolbar
 
-Suggested branch: `frontend-forum-rich-text`
+Suggested branch: `frontend-forum-rich-text` — **complete, pending merge**
 
-**File:** `src/pages/ThreadPage.tsx` — `RichReplyEditor` component (and thread creation modal in
-`ForumPage.tsx`)
-
-The current composer is a raw `<textarea>` with no formatting assistance. Non-technical users will
-not write markdown. A toolbar with common formatting buttons dramatically lowers the barrier.
-
-- [ ] Create a shared `MarkdownToolbar` component at `src/components/MarkdownToolbar.tsx`:
-  ```tsx
-  interface MarkdownToolbarProps {
-    textareaRef: React.RefObject<HTMLTextAreaElement>;
-    onChange: (newValue: string) => void;
-  }
-  ```
-  The toolbar wraps text selection with the appropriate markdown syntax by reading
-  `textareaRef.current?.selectionStart` and `selectionEnd`, replacing the selection.
-
-- [ ] Implement the following toolbar buttons. Each button calls a `wrapSelection(prefix, suffix)`
-  helper that:
-  1. Gets the current selection range from `selectionStart` / `selectionEnd`.
-  2. Wraps the selected text (or inserts placeholder text if nothing is selected).
-  3. Calls `onChange` with the new string.
-  4. Restores focus and cursor position to the textarea.
-
-  | Button | Icon | Markdown inserted |
-  |---|---|---|
-  | Bold | **B** | `**selected text**` |
-  | Italic | *I* | `*selected text*` |
-  | Strikethrough | ~~S~~ | `~~selected text~~` |
-  | Link | 🔗 | `[selected text](url)` — prompt for URL |
-  | Inline code | `</>` | `` `selected text` `` |
-  | Code block | 📋 | ` ```\nselected text\n``` ` |
-  | Blockquote | " | `> selected text` |
-  | Unordered list | • | `- selected text` |
-  | Ordered list | 1. | `1. selected text` |
-  | Spoiler | 👁 | `<details><summary>Spoiler</summary>\nselected text\n</details>` |
-
-- [ ] Place `<MarkdownToolbar>` above the `<textarea>` in both the reply composer in `ThreadPage.tsx`
-  and the first-post textarea in the thread creation modal in `ForumPage.tsx`.
-- [ ] The toolbar should be scrollable horizontally on narrow screens so it does not wrap onto
-  multiple lines.
+- [x] Created `src/components/MarkdownToolbar.tsx` — self-contained, works with any textarea via ref
+- [x] Buttons: Bold, Italic, Strikethrough, Link (prompts for URL), Inline code, Code block, Blockquote, Unordered list, Ordered list, Spoiler (`<details>`)
+- [x] `wrapSelection`, `prefixLines`, `insert` helpers restore focus and cursor/selection after each action
+- [x] Horizontally scrollable on narrow screens (`overflow-x-auto` + `flex` with `shrink-0` buttons)
+- [x] Replaces existing B/I buttons in `RichReplyEditor.tsx`; Image/GIF + List buttons remain after it
+- [x] Added above first-post textarea in `NewThreadModal` in `ForumPage.tsx`
 
 ---
 

--- a/src/components/MarkdownToolbar.tsx
+++ b/src/components/MarkdownToolbar.tsx
@@ -2,7 +2,7 @@ import type React from "react";
 
 interface MarkdownToolbarProps {
   /** Ref to the textarea being formatted */
-  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   /** Current textarea value */
   value: string;
   /** Called with the new value after a format action */

--- a/src/components/MarkdownToolbar.tsx
+++ b/src/components/MarkdownToolbar.tsx
@@ -1,0 +1,174 @@
+import type React from "react";
+
+interface MarkdownToolbarProps {
+  /** Ref to the textarea being formatted */
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  /** Current textarea value */
+  value: string;
+  /** Called with the new value after a format action */
+  onChange: (newValue: string) => void;
+}
+
+/**
+ * Horizontal scrollable markdown formatting toolbar.
+ * Works with any <textarea> via ref — no editor framework needed.
+ */
+export default function MarkdownToolbar({
+  textareaRef,
+  value,
+  onChange,
+}: MarkdownToolbarProps) {
+  const btn =
+    "shrink-0 rounded border border-slate-200 px-2 py-1 text-xs text-slate-700 hover:bg-slate-50 dark:border-[#3a3028] dark:text-slate-200 dark:hover:bg-[#241d19]";
+
+  /** Wrap the current selection (or insert placeholder) with left/right tokens. */
+  function wrapSelection(left: string, right = left, placeholder = "text") {
+    const el = textareaRef.current;
+    if (!el) return;
+    const start = el.selectionStart ?? 0;
+    const end = el.selectionEnd ?? 0;
+    const sel = value.slice(start, end) || placeholder;
+    const next =
+      value.slice(0, start) + left + sel + right + value.slice(end);
+    onChange(next);
+    queueMicrotask(() => {
+      el.focus();
+      const s = start + left.length;
+      el.setSelectionRange(s, s + sel.length);
+    });
+  }
+
+  /** Prefix every line in the selection (or current line) with a string. */
+  function prefixLines(prefix: string, placeholder = "item") {
+    const el = textareaRef.current;
+    if (!el) return;
+    const start = el.selectionStart ?? 0;
+    const end = el.selectionEnd ?? 0;
+    const sel = value.slice(start, end).trim();
+    const lines = sel ? sel.split("\n") : [placeholder];
+    const prefixed = lines.map((l) => `${prefix}${l}`).join("\n");
+    const next = value.slice(0, start) + prefixed + value.slice(end);
+    onChange(next);
+    queueMicrotask(() => {
+      el.focus();
+      el.setSelectionRange(start, start + prefixed.length);
+    });
+  }
+
+  /** Insert a block at the cursor (replaces selection). */
+  function insert(text: string) {
+    const el = textareaRef.current;
+    if (!el) return;
+    const start = el.selectionStart ?? 0;
+    const end = el.selectionEnd ?? 0;
+    const next = value.slice(0, start) + text + value.slice(end);
+    onChange(next);
+    queueMicrotask(() => {
+      el.focus();
+      el.setSelectionRange(start + text.length, start + text.length);
+    });
+  }
+
+  function handleLink() {
+    const el = textareaRef.current;
+    if (!el) return;
+    const start = el.selectionStart ?? 0;
+    const end = el.selectionEnd ?? 0;
+    const sel = value.slice(start, end) || "link text";
+    const url = window.prompt("Enter URL:", "https://");
+    if (!url) return;
+    const md = `[${sel}](${url})`;
+    const next = value.slice(0, start) + md + value.slice(end);
+    onChange(next);
+    queueMicrotask(() => {
+      el.focus();
+      el.setSelectionRange(start, start + md.length);
+    });
+  }
+
+  const actions: {
+    label: string;
+    title: string;
+    className?: string;
+    action: () => void;
+  }[] = [
+    {
+      label: "B",
+      title: "Bold",
+      className: "font-bold",
+      action: () => wrapSelection("**"),
+    },
+    {
+      label: "I",
+      title: "Italic",
+      className: "italic",
+      action: () => wrapSelection("*"),
+    },
+    {
+      label: "S̶",
+      title: "Strikethrough",
+      action: () => wrapSelection("~~"),
+    },
+    {
+      label: "🔗",
+      title: "Link",
+      action: handleLink,
+    },
+    {
+      label: "`•`",
+      title: "Inline code",
+      action: () => wrapSelection("`", "`", "code"),
+    },
+    {
+      label: "```",
+      title: "Code block",
+      action: () => wrapSelection("```\n", "\n```", "code"),
+    },
+    {
+      label: "❝",
+      title: "Blockquote",
+      action: () => prefixLines("> "),
+    },
+    {
+      label: "•—",
+      title: "Unordered list",
+      action: () => prefixLines("- "),
+    },
+    {
+      label: "1.",
+      title: "Ordered list",
+      action: () => prefixLines("1. "),
+    },
+    {
+      label: "👁",
+      title: "Spoiler (collapsible)",
+      action: () => {
+        const el = textareaRef.current;
+        if (!el) return;
+        const start = el.selectionStart ?? 0;
+        const end = el.selectionEnd ?? 0;
+        const sel = value.slice(start, end).trim() || "hidden content";
+        const block = `<details><summary>Spoiler</summary>\n\n${sel}\n\n</details>`;
+        insert(block);
+      },
+    },
+  ];
+
+  return (
+    <div className="overflow-x-auto pb-1">
+      <div className="flex items-center gap-1 text-sm">
+        {actions.map(({ label, title, className, action }) => (
+          <button
+            key={title}
+            type="button"
+            title={title}
+            onClick={action}
+            className={`${btn}${className ? ` ${className}` : ""}`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RichReplyEditor.tsx
+++ b/src/components/RichReplyEditor.tsx
@@ -59,7 +59,6 @@ export default function RichReplyEditor({
     if (!draftKey) return;
     const saved = localStorage.getItem(draftKey);
     if (saved) setValue(saved);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftKey]);
 
   // Save draft on change (debounced 1 s)
@@ -119,23 +118,6 @@ export default function RichReplyEditor({
     }
     return fallback;
   }
-
-  const wrapSelection = (left: string, right = left) => {
-    const el = taRef.current;
-    if (!el) return;
-    const start = el.selectionStart ?? 0;
-    const end = el.selectionEnd ?? 0;
-    const before = value.slice(0, start);
-    const sel = value.slice(start, end);
-    const after = value.slice(end);
-    const next = `${before}${left}${sel}${right}${after}`;
-    setValue(next);
-    queueMicrotask(() => {
-      el.focus();
-      const cursorStart = start + left.length;
-      el.setSelectionRange(cursorStart, cursorStart + sel.length);
-    });
-  };
 
   const extractIds = (text: string) =>
     Array.from(text.matchAll(/\(series:(\d+)\)/g)).map((m) => Number(m[1]));

--- a/src/components/RichReplyEditor.tsx
+++ b/src/components/RichReplyEditor.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import MarkdownToolbar from "./MarkdownToolbar";
 import type { ForumSeriesRef, ReadingList } from "../api/manApi";
 import {
   forumSeriesSearch,
@@ -360,23 +361,15 @@ export default function RichReplyEditor({
           : "bg-white dark:bg-[linear-gradient(145deg,_rgba(27,22,19,0.98),_rgba(21,17,14,0.98))]"
       }`}
     >
+      <div className="relative mb-2">
+        <MarkdownToolbar
+          textareaRef={taRef}
+          value={value}
+          onChange={setValue}
+        />
+      </div>
+
       <div className="relative mb-2 flex items-center gap-2 text-sm">
-        <button
-          type="button"
-          className={toolbarButtonClass}
-          onClick={() => wrapSelection("**")}
-          title="Bold (**text**)"
-        >
-          B
-        </button>
-        <button
-          type="button"
-          className={`${toolbarButtonClass} italic`}
-          onClick={() => wrapSelection("*")}
-          title="Italic (*text*)"
-        >
-          I
-        </button>
         <button
           type="button"
           className={toolbarButtonClass}

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -25,6 +25,7 @@ import UserAvatar from "../components/UserAvatar";
 import { RankerBadge } from "../components/RankerBadge";
 import { inlineUsernameClassName } from "../util/userDisplay";
 import { getTopRankMap } from "../util/rankMap";
+import MarkdownToolbar from "../components/MarkdownToolbar";
 
 const MAX_THREADS_PER_USER = 10;
 const MAX_SERIES_REFS = 10;
@@ -1122,6 +1123,13 @@ function NewThreadModal({
         />
 
         {/* body with @-mention support */}
+        <div className="mb-1">
+          <MarkdownToolbar
+            textareaRef={mdRef}
+            value={md}
+            onChange={setMd}
+          />
+        </div>
         <div className="relative">
           <textarea
             ref={mdRef}


### PR DESCRIPTION
Adds a shared markdown formatting toolbar to the reply composer and new thread modal.

- New src/components/MarkdownToolbar.tsx — works with any textarea via ref, no editor framework
- Buttons: Bold, Italic, Strikethrough, Link (URL prompt), Inline code, Code block, Blockquote, Unordered list, Ordered list, Spoiler (details/summary)
- Wraps selection or inserts placeholder; restores focus and cursor after every action
- Horizontally scrollable on narrow screens so buttons never wrap
- Replaces existing B/I buttons in RichReplyEditor; Image/GIF and List buttons remain
- Also placed above the first-post textarea in the new thread modal