### PR TITLE
feat(forum): thread pinning UI — pin badge, amber styling, admin pin …

### DIFF
--- a/FORUM_IMPROVEMENTS_TODO.md
+++ b/FORUM_IMPROVEMENTS_TODO.md
@@ -120,46 +120,16 @@ Suggested branch: `frontend-forum-rich-text` — **complete, pending merge**
 
 ---
 
-## Phase 4: Thread Pinning UI
+## ✅ Phase 4: Thread Pinning UI
 
-Suggested branch: `frontend-forum-pinning`
+Suggested branch: `frontend-forum-pinning` — **complete, pending merge**
 
-**Backend dependency:** Requires backend Phase 1c (`is_pinned` column and `PATCH /forum/threads/{id}/pin`
-endpoint) to be deployed first.
-
-**Files:** `src/pages/ForumPage.tsx`, `src/api/manApi.ts`
-
-### 4a — API function
-
-Add to `src/api/manApi.ts`:
-```typescript
-export interface PinToggleOut {
-  id: number;
-  is_pinned: boolean;
-}
-
-export const setThreadPin = async (
-  threadId: number,
-  pinned: boolean
-): Promise<PinToggleOut> => {
-  const res = await api.patch<PinToggleOut>(`/forum/threads/${threadId}/pin`, { pinned });
-  return res.data;
-};
-```
-
-### 4b — Thread list changes
-
-- [ ] Update `ForumThreadOut` type in `manApi.ts` to include `is_pinned: boolean` and
-  `view_count: number` (from backend Phase 1b).
-- [ ] In `ForumPage.tsx`, remove the client-side patch notes pin hack (the check that pins a thread
-  whose title contains a specific string). The backend now returns `is_pinned` correctly.
-- [ ] In the thread list render, show a distinct visual treatment for pinned threads:
-  - A 📌 pin icon at the start of the thread row
-  - A subtle background or border color difference (e.g. a faint amber left border)
-  - The text "Pinned" as a small badge
-- [ ] Admin controls: when the signed-in user is an ADMIN, show a pin/unpin button in the thread row
-  actions (alongside the existing lock/delete admin controls). Tapping it calls `setThreadPin`.
-  Optimistically toggle `is_pinned` in the thread list state and revert on error.
+- [x] `is_pinned?: boolean` and `view_count?: number` added to `ForumThread` type in `manApi.ts`
+- [x] `setThreadPin(thread_id, pinned)` API function added
+- [x] Client-side `promotePatchNotes` hack removed — `PATCH_NOTES_TITLE`, `normalize`, and `promotePatchNotes` all deleted
+- [x] Pinned threads get amber left border + warm amber background in thread list
+- [x] 📌 icon prefixed to pinned thread titles; "Pinned" amber badge in meta row
+- [x] Admin pin/unpin button in thread row actions — optimistic update, reverts on error
 
 ---
 

--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -463,6 +463,8 @@ export type ForumThread = {
   series_refs: ForumSeriesRef[];
   locked?: boolean;
   latest_first?: boolean;
+  is_pinned?: boolean;
+  view_count?: number;
 };
 export type ForumPost = {
   id: number;
@@ -1407,6 +1409,17 @@ export async function lockForumThread(
   const res = await api.patch<{ id: number; locked: boolean }>(
     `/forum/threads/${thread_id}/lock`,
     { locked }
+  );
+  return res.data;
+}
+
+export async function setThreadPin(
+  thread_id: number,
+  pinned: boolean
+): Promise<{ id: number; is_pinned: boolean }> {
+  const res = await api.patch<{ id: number; is_pinned: boolean }>(
+    `/forum/threads/${thread_id}/pin`,
+    { pinned }
   );
   return res.data;
 }

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -8,6 +8,7 @@ import {
   getForumThread,
   updateForumThread,
   listForumThreadsPaged,
+  setThreadPin,
 } from "../api/manApi";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useUser } from "../login/useUser";
@@ -29,19 +30,6 @@ import MarkdownToolbar from "../components/MarkdownToolbar";
 
 const MAX_THREADS_PER_USER = 10;
 const MAX_SERIES_REFS = 10;
-const PATCH_NOTES_TITLE = "Patch Notes & Site Updates";
-const normalize = (s: string) => (s || "").trim().toLowerCase();
-
-function promotePatchNotes(list: ForumThread[]) {
-  const i = list.findIndex(
-    (t) => normalize(t.title) === normalize(PATCH_NOTES_TITLE)
-  );
-  if (i > 0) {
-    const [pinned] = list.splice(i, 1);
-    list.unshift(pinned);
-  }
-  return list;
-}
 
 function SeriesRefPill({ s }: { s: ForumThread["series_refs"][number] }) {
   return (
@@ -207,9 +195,7 @@ export default function ForumPage() {
 
   const load = async () => {
     const r = await listForumThreadsPaged(q, page, pageSize, { sort: sortBy });
-    // Only promote pinned/patch notes on page 1 to avoid duplicates
-    const items =
-      page === 1 ? promotePatchNotes(r.items.slice()) : r.items.slice();
+    const items = r.items.slice();
 
     setThreads(items);
     setTotal(r.total);
@@ -390,8 +376,7 @@ export default function ForumPage() {
         {threads.map((t) => {
           const isOwner = t.author_username === myName;
           const canDelete = isAdmin || isOwner;
-          const isPatchNotes =
-            normalize(t.title) === normalize(PATCH_NOTES_TITLE);
+          const isPinned = !!t.is_pinned;
 
           return (
             <li
@@ -413,7 +398,11 @@ export default function ForumPage() {
                   navigate(`/forum/${t.id}`);
                 }
               }}
-              className="cursor-pointer rounded-[1.75rem] border border-white/70 bg-white/40 p-4 shadow-sm ring-1 ring-black/5 backdrop-blur-md transition hover:bg-white/60 hover:shadow-md focus:outline-none focus:ring-4 focus:ring-blue-200 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,rgba(29,24,20,0.98),rgba(21,17,14,0.98))] dark:ring-[rgba(255,255,255,0.03)] dark:shadow-[0_16px_36px_rgba(0,0,0,0.4)] dark:hover:bg-[linear-gradient(145deg,rgba(35,28,23,0.98),rgba(24,20,16,0.98))] dark:focus:ring-blue-950/50"
+              className={`cursor-pointer rounded-[1.75rem] border p-4 shadow-sm ring-1 ring-black/5 backdrop-blur-md transition hover:shadow-md focus:outline-none focus:ring-4 focus:ring-blue-200 dark:ring-[rgba(255,255,255,0.03)] dark:shadow-[0_16px_36px_rgba(0,0,0,0.4)] dark:focus:ring-blue-950/50 ${
+                isPinned
+                  ? "border-l-4 border-amber-300 bg-amber-50/60 hover:bg-amber-50/80 dark:border-amber-700/70 dark:bg-[linear-gradient(145deg,rgba(40,30,10,0.98),rgba(28,21,8,0.98))] dark:hover:bg-[linear-gradient(145deg,rgba(48,36,12,0.98),rgba(34,25,10,0.98))]"
+                  : "border-white/70 bg-white/40 hover:bg-white/60 dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,rgba(29,24,20,0.98),rgba(21,17,14,0.98))] dark:hover:bg-[linear-gradient(145deg,rgba(35,28,23,0.98),rgba(24,20,16,0.98))]"
+              }`}
             >
               <div className="flex flex-col gap-3">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -421,36 +410,82 @@ export default function ForumPage() {
                     to={`/forum/${t.id}`}
                     className="text-base font-semibold leading-6 text-slate-900 hover:underline dark:text-stone-50 sm:text-lg"
                   >
+                    {isPinned && <span className="mr-1">📌</span>}
                     {stripMdHeading(t.title)}
                   </Link>
 
-                  {canDelete && (
+                  {(canDelete || isAdmin) && (
                     <div className="flex items-center gap-2 self-start sm:self-auto">
-                      <button
-                        type="button"
-                        title="Edit thread"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          setEditingThread(t);
-                          setEditingBody("");
-                          (async () => {
-                            try {
-                              const data = await getForumThread(t.id);
-                              setEditingBody(
-                                data.posts?.[0]?.content_markdown ?? ""
-                              );
-                            } catch {
-                              // silent; keep empty body if fetch fails
-                            }
-                          })();
-                        }}
-                        className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 dark:border-[#3a3028] dark:text-stone-200 dark:hover:bg-[linear-gradient(145deg,_rgba(34,47,83,0.8),_rgba(24,31,55,0.8))] dark:hover:text-blue-200"
-                      >
-                        Edit
-                      </button>
+                      {canDelete && (
+                        <button
+                          type="button"
+                          title="Edit thread"
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            setEditingThread(t);
+                            setEditingBody("");
+                            (async () => {
+                              try {
+                                const data = await getForumThread(t.id);
+                                setEditingBody(
+                                  data.posts?.[0]?.content_markdown ?? ""
+                                );
+                              } catch {
+                                // silent; keep empty body if fetch fails
+                              }
+                            })();
+                          }}
+                          className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 transition hover:border-blue-300 hover:bg-blue-50 hover:text-blue-700 dark:border-[#3a3028] dark:text-stone-200 dark:hover:bg-[linear-gradient(145deg,_rgba(34,47,83,0.8),_rgba(24,31,55,0.8))] dark:hover:text-blue-200"
+                        >
+                          Edit
+                        </button>
+                      )}
 
-                      {!t.locked && (
+                      {isAdmin && (
+                        <button
+                          type="button"
+                          title={isPinned ? "Unpin thread" : "Pin thread"}
+                          onClick={async (e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            // Optimistic update
+                            setThreads((prev) =>
+                              prev.map((th) =>
+                                th.id === t.id
+                                  ? { ...th, is_pinned: !isPinned }
+                                  : th
+                              )
+                            );
+                            try {
+                              await setThreadPin(t.id, !isPinned);
+                            } catch {
+                              // Revert on error
+                              setThreads((prev) =>
+                                prev.map((th) =>
+                                  th.id === t.id
+                                    ? { ...th, is_pinned: isPinned }
+                                    : th
+                                )
+                              );
+                              notice.show({
+                                title: "Action failed",
+                                message: "Could not update pin status.",
+                                variant: "error",
+                              });
+                            }
+                          }}
+                          className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-medium transition ${
+                            isPinned
+                              ? "border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100 dark:border-amber-700/60 dark:bg-amber-950/30 dark:text-amber-300"
+                              : "border-slate-200 text-slate-600 hover:border-amber-300 hover:bg-amber-50 hover:text-amber-700 dark:border-[#3a3028] dark:text-stone-200 dark:hover:border-amber-700/60 dark:hover:bg-amber-950/30 dark:hover:text-amber-300"
+                          }`}
+                        >
+                          {isPinned ? "📌 Pinned" : "Pin"}
+                        </button>
+                      )}
+
+                      {canDelete && !t.locked && (
                         <button
                           type="button"
                           title="Delete thread"
@@ -507,8 +542,8 @@ export default function ForumPage() {
                     ) : null}
                   </div>
 
-                  {isPatchNotes && (
-                    <span className="inline-flex items-center rounded-full bg-violet-50 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-violet-700 dark:bg-violet-950/35 dark:text-violet-200">
+                  {isPinned && (
+                    <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-amber-800 dark:bg-amber-950/35 dark:text-amber-200">
                       Pinned
                     </span>
                   )}


### PR DESCRIPTION
Replaces the client-side patch notes pin hack with proper is_pinned support from the backend.

- is_pinned and view_count added to ForumThread type
- setThreadPin API function added (PATCH /forum/threads/{id}/pin)
- Removed promotePatchNotes, PATCH_NOTES_TITLE, normalize (all dead code now)
- Pinned threads: amber left border, warm background, 📌 icon in title, "Pinned" badge
- Admin users see a Pin/Pinned button in each thread row; optimistic toggle with error revert