### PR TITLE
feat(forum): post reporting UI — report button, inline form, 409 hand…

### DIFF
--- a/FORUM_IMPROVEMENTS_TODO.md
+++ b/FORUM_IMPROVEMENTS_TODO.md
@@ -133,43 +133,16 @@ Suggested branch: `frontend-forum-pinning` — **complete, pending merge**
 
 ---
 
-## Phase 5: Post Reporting UI
+## ✅ Phase 5: Post Reporting UI
 
-Suggested branch: `frontend-forum-post-reporting`
+Suggested branch: `frontend-forum-post-reporting` — **complete, pending merge**
 
-**Backend dependency:** Requires backend Phase 3 (`POST /forum/threads/{id}/posts/{postId}/report`)
-to be deployed first.
-
-**File:** `src/pages/ThreadPage.tsx`, `src/api/manApi.ts`
-
-### 5a — API function
-
-Add to `src/api/manApi.ts`:
-```typescript
-export const reportPost = async (
-  threadId: number,
-  postId: number,
-  reason?: string
-): Promise<{ message: string }> => {
-  const res = await api.post(`/forum/threads/${threadId}/posts/${postId}/report`, { reason });
-  return res.data;
-};
-```
-
-### 5b — Report button on posts
-
-- [ ] Add a "⚑ Report" button to the post action row in `ThreadPage.tsx`.
-  Show it only to authenticated users and only on posts where the signed-in user is not the author
-  (block self-reporting client-side to match backend behavior).
-- [ ] Clicking "Report" opens a small inline form or modal with:
-  - A header: "Report this post"
-  - An optional textarea: "Reason (optional)" — max 500 characters
-  - A "Submit Report" button
-  - A cancel action
-- [ ] On submit, call `reportPost`. On 201 success, show `toast.success("Report submitted. Our team will review it.")` and close the form.
-- [ ] On 409 (already reported), show `toast.error("You have already reported this post.")`.
-- [ ] Disable the Report button after a successful submission so the user cannot double-report within
-  the same page session (persist via local component state `const [reported, setReported] = useState(false)`).
+- [x] `reportPost(thread_id, post_id, reason?)` added to `manApi.ts`
+- [x] ⚑ Report button on each reply — shown only to authenticated users who are not the post author
+- [x] Clicking opens an inline rose-tinted form: optional reason textarea (max 500 chars) + Submit + Cancel
+- [x] On success: notifies "Report submitted. Our team will review it." and hides form + button
+- [x] On 409: notifies "You have already reported this post."
+- [x] `reported` state prevents double-reporting within the same session
 
 ---
 

--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -1424,6 +1424,18 @@ export async function setThreadPin(
   return res.data;
 }
 
+export async function reportPost(
+  thread_id: number,
+  post_id: number,
+  reason?: string
+): Promise<{ message: string }> {
+  const res = await api.post<{ message: string }>(
+    `/forum/threads/${thread_id}/posts/${post_id}/report`,
+    { reason }
+  );
+  return res.data;
+}
+
 export async function updateForumThreadSettings(
   thread_id: number,
   input: { latest_first?: boolean }

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -18,6 +18,7 @@ import {
   editForumPost,
   setForumPostVote,
   getForumThreadPaged,
+  reportPost,
 } from "../api/manApi";
 import { useUser } from "../login/useUser";
 import ReactMarkdown from "react-markdown";
@@ -1460,6 +1461,10 @@ function ReplyBranch({
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [busyDelete, setBusyDelete] = useState(false);
   const [replyComposerOpen, setReplyComposerOpen] = useState(false);
+  const [reportFormOpen, setReportFormOpen] = useState(false);
+  const [reportReason, setReportReason] = useState("");
+  const [reported, setReported] = useState(false);
+  const [reportBusy, setReportBusy] = useState(false);
 
   function lightenHex(hex: string, amount = 0.35) {
     const m = hex.match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
@@ -1711,6 +1716,71 @@ function ReplyBranch({
               }
             }}
           />
+
+          {/* Report button — visible to authenticated non-authors on unlocked threads */}
+          {currentUsername && currentUsername !== post.author_username && !reported && (
+            <button
+              type="button"
+              onClick={() => setReportFormOpen((o) => !o)}
+              className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-500 transition hover:border-rose-300 hover:bg-rose-50 hover:text-rose-600 dark:border-[#3a3028] dark:text-slate-400 dark:hover:border-rose-800/60 dark:hover:bg-rose-950/20 dark:hover:text-rose-400"
+              title="Report this post"
+            >
+              ⚑ Report
+            </button>
+          )}
+
+          {reportFormOpen && !reported && (
+            <div
+              className="w-full mt-2 rounded-2xl border border-rose-200 bg-rose-50/60 px-3 py-3 dark:border-rose-800/40 dark:bg-rose-950/20"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <p className="mb-2 text-xs font-semibold text-rose-700 dark:text-rose-300">
+                Report this post
+              </p>
+              <textarea
+                value={reportReason}
+                onChange={(e) => setReportReason(e.target.value)}
+                maxLength={500}
+                placeholder="Reason (optional)"
+                rows={2}
+                className="w-full rounded-xl border border-rose-200 bg-white px-3 py-2 text-xs text-slate-800 placeholder:text-slate-400 dark:border-rose-800/40 dark:bg-[#18120f] dark:text-slate-100"
+              />
+              <div className="mt-2 flex items-center gap-2">
+                <button
+                  type="button"
+                  disabled={reportBusy}
+                  onClick={async () => {
+                    setReportBusy(true);
+                    try {
+                      await reportPost(threadId, post.id, reportReason.trim() || undefined);
+                      setReported(true);
+                      setReportFormOpen(false);
+                      notify({ message: "Report submitted. Our team will review it.", variant: "success" });
+                    } catch (err: unknown) {
+                      const status = (err as { response?: { status?: number } })?.response?.status;
+                      if (status === 409) {
+                        notify({ message: "You have already reported this post.", variant: "warning" });
+                      } else {
+                        notify({ message: "Failed to submit report.", variant: "error" });
+                      }
+                    } finally {
+                      setReportBusy(false);
+                    }
+                  }}
+                  className="rounded-full bg-rose-600 px-3 py-1 text-xs font-medium text-white disabled:opacity-50 hover:bg-rose-700"
+                >
+                  {reportBusy ? "Submitting..." : "Submit report"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setReportFormOpen(false); setReportReason(""); }}
+                  className="rounded-full border border-slate-200 px-3 py-1 text-xs text-slate-600 hover:bg-slate-50 dark:border-[#3a3028] dark:text-slate-300"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
 
           {!isUpdatesMode ? (
             !locked || isAdmin ? (


### PR DESCRIPTION
Adds post reporting to the thread view.

- reportPost API function added (POST /forum/threads/{id}/posts/{postId}/report)
- ⚑ Report button on each reply, visible to authenticated users who are not the post author
- Clicking opens an inline rose-tinted form with optional reason textarea (max 500 chars)
- Success: shows notification and permanently hides the report button for that post
- 409 (duplicate report): shows "You have already reported this post" warning