### PR TITLE
feat(forum): post bookmarking — bookmark button, saved posts tab in a…

### DIFF
--- a/FORUM_IMPROVEMENTS_TODO.md
+++ b/FORUM_IMPROVEMENTS_TODO.md
@@ -146,13 +146,15 @@ Suggested branch: `frontend-forum-post-reporting` — **complete, pending merge*
 
 ---
 
-## Phase 6: Thread Bookmarking UI
+## ✅ Phase 6: Thread Bookmarking UI
 
-Suggested branch: `frontend-forum-bookmarking`
+Suggested branch: `frontend-forum-bookmarking` — **complete, pending merge**
 
-**Backend dependency:** Requires backend Phase 4 (`ForumBookmark` table and endpoints) to be deployed first.
-
-**Files:** `src/pages/ThreadPage.tsx`, `src/api/manApi.ts`
+- [x] `viewer_has_bookmarked` added to `ForumPost` type
+- [x] `togglePostBookmark` and `fetchMyBookmarks` API functions added
+- [x] 🔖 bookmark button on every reply — amber when saved, outline when not; optimistic toggle with revert on error
+- [x] "Saved" tab added to `ForumActivitySection` — lazy loads on first open; shows excerpt, author, date, View link, and ✕ remove button
+- [x] Removing from Saved list optimistically removes the row without a page reload
 
 ### 6a — API functions
 

--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -483,6 +483,7 @@ export type ForumPost = {
   viewer_vote?: "UPVOTE" | "DOWNVOTE" | null;
   heart_count?: number;
   viewer_has_hearted?: boolean;
+  viewer_has_bookmarked?: boolean;
 };
 
 export interface Issue {
@@ -1421,6 +1422,26 @@ export async function setThreadPin(
     `/forum/threads/${thread_id}/pin`,
     { pinned }
   );
+  return res.data;
+}
+
+export async function togglePostBookmark(
+  thread_id: number,
+  post_id: number
+): Promise<{ bookmarked: boolean }> {
+  const res = await api.post<{ bookmarked: boolean }>(
+    `/forum/threads/${thread_id}/posts/${post_id}/bookmark`
+  );
+  return res.data;
+}
+
+export async function fetchMyBookmarks(
+  page = 1,
+  page_size = 20
+): Promise<Paginated<ForumPost>> {
+  const res = await api.get<Paginated<ForumPost>>("/forum/me/bookmarks", {
+    params: { page, page_size },
+  });
   return res.data;
 }
 

--- a/src/components/ForumActivitySection.tsx
+++ b/src/components/ForumActivitySection.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import type { ForumThread, ForumPost, Paginated } from "../api/manApi";
-import { getMyForumThreads, getMyForumPosts, getMyForumVotes } from "../api/manApi";
+import { getMyForumThreads, getMyForumPosts, getMyForumVotes, fetchMyBookmarks, togglePostBookmark } from "../api/manApi";
 import { mdToPlainText } from "../util/strings";
+import { wasEdited } from "../util/dateUtils";
 
-type Tab = "threads" | "posts" | "votes";
+type Tab = "threads" | "posts" | "votes" | "saved";
 
 const PAGE_SIZE = 10;
 
@@ -116,6 +117,12 @@ export function ForumActivitySection() {
   const [votesError, setVotesError] = useState<string | null>(null);
   const [votesPage, setVotesPage] = useState(1);
 
+  // Saved (bookmarks)
+  const [savedData, setSavedData] = useState<Paginated<ForumPost> | null>(null);
+  const [savedLoading, setSavedLoading] = useState(false);
+  const [savedError, setSavedError] = useState<string | null>(null);
+  const [savedPage, setSavedPage] = useState(1);
+
   // Fetch all three on mount so counts are always visible in every tab pill.
   // Re-fetch the relevant tab when its page changes (page > 1 guard avoids
   // a duplicate fetch since mount already loaded page 1).
@@ -169,10 +176,23 @@ export function ForumActivitySection() {
     return () => { cancelled = true; };
   }, [votesPage]);
 
+  // Load bookmarks when tab first opened, and on page changes
+  useEffect(() => {
+    if (tab !== "saved") return;
+    let cancelled = false;
+    setSavedLoading(true);
+    setSavedError(null);
+    fetchMyBookmarks(savedPage, PAGE_SIZE)
+      .then((d) => { if (!cancelled) { setSavedData(d); setSavedLoading(false); } })
+      .catch(() => { if (!cancelled) { setSavedError("Could not load saved posts."); setSavedLoading(false); } });
+    return () => { cancelled = true; };
+  }, [tab, savedPage]);
+
   const tabConfig: { key: Tab; label: string; count: number | undefined; loading: boolean }[] = [
     { key: "threads", label: "Threads", count: threadsData?.total, loading: threadsLoading && threadsData === null },
     { key: "posts", label: "Replies", count: postsData?.total, loading: postsLoading && postsData === null },
     { key: "votes", label: "Votes", count: votesData?.total, loading: votesLoading && votesData === null },
+    { key: "saved", label: "Saved", count: savedData?.total, loading: savedLoading && savedData === null },
   ];
 
   return (
@@ -280,8 +300,11 @@ export function ForumActivitySection() {
                 </div>
               )}
               <div className="flex items-center justify-between gap-3">
-                <p className="text-xs text-slate-400 dark:text-slate-500">
+                <p className="flex items-center gap-1.5 text-xs text-slate-400 dark:text-slate-500">
                   {shortDate(p.created_at)}
+                  {wasEdited(p.created_at, p.updated_at) && (
+                    <span className="italic">(edited)</span>
+                  )}
                 </p>
                 {p.thread_id ? (
                   <Link
@@ -337,8 +360,11 @@ export function ForumActivitySection() {
                 ) : null}
               </div>
               <div className="flex items-center justify-between gap-3">
-                <p className="text-xs text-slate-400 dark:text-slate-500">
+                <p className="flex items-center gap-1.5 text-xs text-slate-400 dark:text-slate-500">
                   {shortDate(p.created_at)}
+                  {wasEdited(p.created_at, p.updated_at) && (
+                    <span className="italic">(edited)</span>
+                  )}
                 </p>
                 {p.thread_id ? (
                   <Link
@@ -358,6 +384,74 @@ export function ForumActivitySection() {
               hasPrev={votesData.has_prev}
               hasNext={votesData.has_next}
               onGo={setVotesPage}
+            />
+          )}
+        </TabShell>
+      )}
+
+      {/* Saved tab */}
+      {tab === "saved" && (
+        <TabShell
+          loading={savedLoading}
+          error={savedError}
+          empty={savedData !== null && savedData.total === 0}
+          emptyMessage="You haven't saved any posts yet."
+        >
+          {savedData?.items.map((p) => (
+            <div
+              key={p.id}
+              className="space-y-2 rounded-2xl border border-slate-100 bg-slate-50/60 p-4 dark:border-[#342b24] dark:bg-[#181310]"
+            >
+              <p className="text-sm leading-relaxed text-slate-700 dark:text-stone-200">
+                {truncate(mdToPlainText(p.content_markdown))}
+              </p>
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-500">
+                  {p.author_username && (
+                    <span>by <span className="font-medium text-slate-600 dark:text-slate-300">{p.author_username}</span></span>
+                  )}
+                  <span>·</span>
+                  <span>{shortDate(p.created_at)}</span>
+                  {wasEdited(p.created_at, p.updated_at) && (
+                    <span className="italic">(edited)</span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2">
+                  {p.thread_id ? (
+                    <Link
+                      to={`/forum/${p.thread_id}#post-${p.id}`}
+                      className="text-xs font-medium text-slate-500 hover:text-slate-800 hover:underline dark:text-slate-400 dark:hover:text-slate-200"
+                    >
+                      View →
+                    </Link>
+                  ) : null}
+                  <button
+                    type="button"
+                    onClick={async () => {
+                      if (!p.thread_id) return;
+                      await togglePostBookmark(p.thread_id, p.id).catch(() => {});
+                      setSavedData((prev) =>
+                        prev
+                          ? { ...prev, items: prev.items.filter((x) => x.id !== p.id), total: prev.total - 1 }
+                          : prev
+                      );
+                    }}
+                    className="rounded-full border border-slate-200 px-2 py-0.5 text-xs text-slate-500 transition hover:border-rose-300 hover:bg-rose-50 hover:text-rose-600 dark:border-[#342b24] dark:text-slate-400 dark:hover:border-rose-800/60 dark:hover:bg-rose-950/20 dark:hover:text-rose-400"
+                    title="Remove bookmark"
+                  >
+                    ✕
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+          {savedData && (
+            <MiniPager
+              page={savedData.page}
+              totalPages={savedData.total_pages}
+              hasPrev={savedData.has_prev}
+              hasNext={savedData.has_next}
+              onGo={setSavedPage}
             />
           )}
         </TabShell>

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -19,6 +19,7 @@ import {
   setForumPostVote,
   getForumThreadPaged,
   reportPost,
+  togglePostBookmark,
 } from "../api/manApi";
 import { useUser } from "../login/useUser";
 import ReactMarkdown from "react-markdown";
@@ -1465,6 +1466,7 @@ function ReplyBranch({
   const [reportReason, setReportReason] = useState("");
   const [reported, setReported] = useState(false);
   const [reportBusy, setReportBusy] = useState(false);
+  const [bookmarked, setBookmarked] = useState(!!post.viewer_has_bookmarked);
 
   function lightenHex(hex: string, amount = 0.35) {
     const m = hex.match(/^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i);
@@ -1716,6 +1718,31 @@ function ReplyBranch({
               }
             }}
           />
+
+          {/* Bookmark button — visible to authenticated users */}
+          {currentUsername && (
+            <button
+              type="button"
+              onClick={async () => {
+                const prev = bookmarked;
+                setBookmarked(!prev);
+                try {
+                  await togglePostBookmark(threadId, post.id);
+                } catch {
+                  setBookmarked(prev);
+                  notify({ title: "Action failed", message: "Could not update bookmark.", variant: "error" });
+                }
+              }}
+              title={bookmarked ? "Remove bookmark" : "Bookmark this post"}
+              className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition ${
+                bookmarked
+                  ? "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700/60 dark:bg-amber-950/30 dark:text-amber-300"
+                  : "border-slate-200 text-slate-500 hover:border-amber-300 hover:bg-amber-50 hover:text-amber-700 dark:border-[#3a3028] dark:text-slate-400 dark:hover:border-amber-700/60 dark:hover:bg-amber-950/20 dark:hover:text-amber-300"
+              }`}
+            >
+              {bookmarked ? "🔖 Saved" : "🔖"}
+            </button>
+          )}
 
           {/* Report button — visible to authenticated non-authors on unlocked threads */}
           {currentUsername && currentUsername !== post.author_username && !reported && (


### PR DESCRIPTION
Adds post bookmarking to threads and a Saved Posts tab to the account page.

- viewer_has_bookmarked added to ForumPost type
- togglePostBookmark + fetchMyBookmarks API functions added
- 🔖 button on every reply (logged-in users only) — amber when saved, outline when not; optimistic toggle
- "Saved" tab in Forum activity section on account page — lazy loads, shows excerpt + author + date
- ✕ Remove button on each saved post removes bookmark optimistically without reload
- (edited) indicator shown on post cards in Replies, Votes, and Saved tabs