### PR TITLE
feat(forum): unread badges on thread list + mark-read on thread view …

### DIFF
--- a/FORUM_IMPROVEMENTS_TODO.md
+++ b/FORUM_IMPROVEMENTS_TODO.md
@@ -419,7 +419,7 @@ Create `src/components/NotificationBell.tsx`:
 
 ---
 
-## Phase 10: Read Tracking — "New Posts" Badges
+## ✅ Phase 10: Read Tracking — "New Posts" Badges
 
 Suggested branch: `frontend-forum-read-tracking`
 

--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -477,6 +477,8 @@ export type ForumThread = {
   viewer_is_following?: boolean;
   category_id?: number | null;
   category_name?: string | null;
+  has_unread?: boolean;
+  unread_count?: number;
 };
 export type ForumPost = {
   id: number;
@@ -1471,6 +1473,13 @@ export async function deleteForumCategory(id: number): Promise<void> {
 export async function fetchForumCategories(): Promise<ForumCategory[]> {
   const res = await api.get<ForumCategory[]>("/forum/categories");
   return res.data;
+}
+
+export async function markThreadRead(
+  thread_id: number,
+  last_seen_post_id: number
+): Promise<void> {
+  await api.post(`/forum/threads/${thread_id}/mark-read`, { last_seen_post_id });
 }
 
 export async function toggleThreadFollow(

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -475,13 +475,24 @@ export default function ForumPage() {
             >
               <div className="flex flex-col gap-3">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <Link
-                    to={`/forum/${t.id}`}
-                    className="text-base font-semibold leading-6 text-slate-900 hover:underline dark:text-stone-50 sm:text-lg"
-                  >
-                    {isPinned && <span className="mr-1">📌</span>}
-                    {stripMdHeading(t.title)}
-                  </Link>
+                  <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <Link
+                      to={`/forum/${t.id}`}
+                      className={`text-base leading-6 hover:underline dark:text-stone-50 sm:text-lg ${
+                        user && t.has_unread
+                          ? "font-bold text-slate-950 dark:text-white"
+                          : "font-semibold text-slate-900 dark:text-stone-50"
+                      }`}
+                    >
+                      {isPinned && <span className="mr-1">📌</span>}
+                      {stripMdHeading(t.title)}
+                    </Link>
+                    {user && t.has_unread && (
+                      <span className="inline-flex items-center rounded-full bg-emerald-500 px-2 py-0.5 text-[10px] font-bold text-white">
+                        {t.unread_count ? `${t.unread_count} new` : "New"}
+                      </span>
+                    )}
+                  </div>
 
                   {(canDelete || isAdmin) && (
                     <div className="flex items-center gap-2 self-start sm:self-auto">

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -21,6 +21,7 @@ import {
   reportPost,
   togglePostBookmark,
   toggleThreadFollow,
+  markThreadRead,
 } from "../api/manApi";
 import { useUser } from "../login/useUser";
 import ReactMarkdown from "react-markdown";
@@ -677,6 +678,14 @@ export default function ThreadPage() {
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [threadId, page]);
+
+  // Mark thread as read after posts load (silent fail — non-critical)
+  useEffect(() => {
+    if (!user || !posts.length) return;
+    const lastPostId = posts[posts.length - 1]?.id;
+    if (!lastPostId) return;
+    markThreadRead(threadId, lastPostId).catch(() => {});
+  }, [posts, threadId, user]);
 
   // Scroll to a specific post when the URL contains a #post-{id} hash.
   // Fires after posts finish loading so the target element is in the DOM.


### PR DESCRIPTION
Adds read state tracking to the forum thread list and thread view.

- has_unread and unread_count added to ForumThread type
- markThreadRead API function added (POST /forum/threads/{id}/mark-read)
- Thread list: unread threads show a green "N new" chip next to the title + bold title
- Thread view: automatically calls markThreadRead with the last visible post ID after each page of posts loads — silent fail so it never breaks the page