### PR TITLE
feat: status filter on home page rankings

### DIFF
--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -1019,13 +1019,15 @@ export const fetchRankedSeriesPaginated = async (
   page: number,
   size: number,
   type?: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  status?: string
 ): Promise<RankedSeries[]> => {
   const res = await api.get<RankedSeries[]>("/series/rankings", {
     params: {
       page,
       page_size: size,
       ...(type ? { type } : {}),
+      ...(status ? { status } : {}),
     },
     signal, // Axios v1 supports AbortController signals
   });

--- a/src/components/StatusStrip.tsx
+++ b/src/components/StatusStrip.tsx
@@ -1,0 +1,64 @@
+import type { SeriesStatus } from "../api/manApi";
+
+type StatusValue = "ONGOING" | "COMPLETE" | "HIATUS" | "SEASON_END";
+
+type Props = {
+  active: SeriesStatus;
+  onSelect: (status: SeriesStatus) => void;
+};
+
+const STATUS_OPTIONS: { label: string; value: StatusValue }[] = [
+  { label: "Ongoing", value: "ONGOING" },
+  { label: "Complete", value: "COMPLETE" },
+  { label: "Hiatus", value: "HIATUS" },
+  { label: "Season End", value: "SEASON_END" },
+];
+
+const DOT_CLASS: Record<StatusValue, string> = {
+  ONGOING: "bg-emerald-500",
+  COMPLETE: "bg-blue-600",
+  HIATUS: "bg-amber-500",
+  SEASON_END: "bg-violet-600",
+};
+
+// Mirrors GenreStrip's tab styling for visual consistency.
+const tabBase =
+  "inline-flex items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition-colors sm:px-3.5 sm:py-2 sm:text-sm sm:tracking-[0.14em]";
+const tabActive =
+  "bg-[linear-gradient(135deg,_#315ff4,_#2347c5)] text-white shadow-[0_12px_26px_-18px_rgba(35,71,197,0.7)] ring-1 ring-inset ring-blue-500/40 dark:bg-[radial-gradient(circle_at_top_left,_rgba(45,212,191,0.16),_transparent_40%),linear-gradient(145deg,_rgba(34,63,124,0.96),_rgba(23,44,96,0.96))] dark:text-white dark:ring-[#3056a5]";
+const tabIdle =
+  "text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-[linear-gradient(145deg,_rgba(35,28,24,0.95),_rgba(24,19,16,0.95))] dark:hover:text-white";
+
+export default function StatusStrip({ active, onSelect }: Props) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 sm:gap-2">
+      <button
+        type="button"
+        className={`${tabBase} ${!active ? tabActive : tabIdle}`}
+        onClick={() => onSelect(null)}
+        title="All statuses"
+      >
+        ALL STATUS
+      </button>
+
+      {STATUS_OPTIONS.map((option) => {
+        const isActive = active === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            className={`${tabBase} ${isActive ? tabActive : tabIdle}`}
+            onClick={() => onSelect(isActive ? null : option.value)}
+            title={option.label}
+          >
+            <span
+              className={`h-2 w-2 rounded-full ${DOT_CLASS[option.value]}`}
+              aria-hidden="true"
+            />
+            {option.label.toUpperCase()}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,6 +10,7 @@ import {
   type RankedSeries,
   type ReadingList,
   type Series,
+  type SeriesStatus,
 } from "../api/manApi";
 import InfiniteScroll from "react-infinite-scroll-component";
 import { useSearch } from "../components/useSearch";
@@ -19,6 +20,7 @@ import CompareManager from "../components/CompareManager";
 import { useUser } from "../login/useUser";
 import ReadingListModal from "../components/ReadingListModal";
 import GenreStrip from "../components/GenreStrip";
+import StatusStrip from "../components/StatusStrip";
 import { canSubmitSeriesUser, isAdminUser } from "../util/roleUtils";
 import {
   absoluteUrl,
@@ -38,6 +40,7 @@ const Home = () => {
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
   const [loading, setLoading] = useState(false);
+  const [activeStatus, setActiveStatus] = useState<SeriesStatus>(null);
   // const [compareList, setCompareList] = useState<RankedSeries[]>([]);
   const [compareError, setCompareError] = useState<string | null>(null);
 
@@ -140,7 +143,13 @@ const Home = () => {
     setLoading(true);
 
     try {
-      const newItems = await fetchRankedSeriesPaginated(page, PAGE_SIZE);
+      const newItems = await fetchRankedSeriesPaginated(
+        page,
+        PAGE_SIZE,
+        undefined,
+        undefined,
+        activeStatus ?? undefined
+      );
       setItems((prev) => {
         const newIds = new Set(prev.map((item) => item.id));
         const filtered = newItems.filter((item) => !newIds.has(item.id));
@@ -153,7 +162,7 @@ const Home = () => {
     } finally {
       setLoading(false);
     }
-  }, [hasMore, page]);
+  }, [hasMore, page, activeStatus]);
 
   useEffect(() => {
     if (compareError) {
@@ -204,7 +213,13 @@ const Home = () => {
         setHasMore(true);
 
         try {
-          const results = await fetchRankedSeriesPaginated(1, PAGE_SIZE);
+          const results = await fetchRankedSeriesPaginated(
+            1,
+            PAGE_SIZE,
+            undefined,
+            undefined,
+            activeStatus ?? undefined
+          );
           setItems(results);
           if (results.length < PAGE_SIZE) setHasMore(false);
         } catch (err) {
@@ -216,7 +231,7 @@ const Home = () => {
     };
 
     fetchData();
-  }, [searchTerm]);
+  }, [searchTerm, activeStatus]);
 
   useEffect(() => {
     if (!searchTerm) loadSeries();
@@ -305,6 +320,11 @@ const Home = () => {
                     {activeGenre}
                   </span>
                 ) : null}
+                {activeStatus ? (
+                  <span className="inline-flex items-center rounded-full bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-100 dark:bg-[linear-gradient(145deg,_rgba(34,47,83,0.82),_rgba(24,31,55,0.82))] dark:text-blue-200 dark:ring-[#475276] sm:px-3 sm:py-1.5 sm:text-sm">
+                    {activeStatus.replace("_", " ")}
+                  </span>
+                ) : null}
                 {searchTerm.trim() ? (
                   <span className="inline-flex max-w-full items-center rounded-full bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-100 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-900 sm:px-3 sm:py-1.5 sm:text-sm">
                     Search: {searchTerm.trim()}
@@ -334,10 +354,21 @@ const Home = () => {
               )}
             </div>
 
+            <StatusStrip
+              active={activeStatus}
+              onSelect={(s) => {
+                setActiveStatus(s);
+                if (s) setSearchTerm("");
+              }}
+            />
+
             <GenreStrip
               genres={derivedGenres}
               active={activeGenre}
-              onSelect={(g) => setSearchTerm(g ?? "")}
+              onSelect={(g) => {
+                setSearchTerm(g ?? "");
+                setActiveStatus(null);
+              }}
             />
           </div>
 


### PR DESCRIPTION
Adds a publication-status filter to the Home page rankings. A new StatusStrip (Ongoing / Complete / Hiatus / Season End, with colored dots) sits above the genre strip and drives a server-side status param on /series/rankings, so results are accurate and paginated. Status and genre/search are mutually exclusive (the genre filter reuses the search endpoint, which isn't status-aware). An active-status chip shows in the header. fetchRankedSeriesPaginated gained an optional trailing status arg so existing callers are unaffected.

