### PR TITLE
docs: add AI-native documentation (CLAUDE.md, AGENTS.md, architecture…

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,48 @@
+# Toon Ranks Frontend — Cursor Rules
+
+## Project identity
+React 18 + TypeScript SPA. Vite build tool. Tailwind CSS (dark mode: class). React Router v6.
+Deployed on AWS Amplify. Backend is a separate FastAPI repo (toonranks-backend).
+
+## Hard rules
+- Never commit directly to `main` or `uat` — feature branches only, merge to `uat` first
+- All API calls go through `src/api/manApi.ts` using the axios instance from `src/api/client.ts`
+- Auth state lives in `UserContext` (src/login/) — never read localStorage for user in components
+- Role checks use `src/util/roleUtils.ts` — never compare role strings inline
+- New routes must be added to `src/App.tsx` — the single routing source of truth
+- No `any` types without an explanatory comment
+- Run `npm run lint` and `npm run build` to verify before finishing
+
+## Styling rules
+- Tailwind CSS only — no inline styles, no CSS modules for new code
+- Dark mode via `dark:` prefix — relies on `dark` class on `<html>` set by ThemeContext
+- Don't hardcode colour values — use Tailwind palette classes
+
+## Key patterns
+- New page → `src/pages/MyPage.tsx` + route entry in `App.tsx`
+- New shared component → `src/components/MyComponent.tsx`
+- New API call → typed function in `src/api/manApi.ts`
+- New pure helper → `src/util/myUtil.ts`
+- Loading states → use ShimmerBox / ShimmerLoader components, not spinners
+- Toasts → react-hot-toast (`toast.success(...)`, `toast.error(...)`)
+- Public pages → include `<Seo>` component for meta tags
+
+## Domain vocabulary
+- Series types: MANGA, MANHWA, MANHUA
+- User roles: GENERAL < CONTRIBUTOR < ADMIN
+- Approval states (backend-driven): DRAFT → PENDING → APPROVED
+- Theme: "light" | "dark" — from ThemeContext
+
+## Key reference files
+- Architecture: docs/ARCHITECTURE.md
+- Conventions: docs/CONVENTIONS.md
+- Deployment: docs/DEPLOYMENT.md
+- All types: src/types/types.ts
+- All API functions: src/api/manApi.ts
+
+## What to avoid
+- Raw fetch() calls for API requests
+- Hardcoding VITE_APP_BASE_URL — use import.meta.env
+- Storing anything beyond token/user in localStorage
+- Inline styles
+- Committing to main or uat directly

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+# Toon Ranks Frontend — Agent Instructions
+
+Universal AI agent entry point (Cursor, GitHub Copilot, Windsurf, Gemini, etc.).
+If you are Claude Code, also read `CLAUDE.md` for the full reference.
+
+---
+
+## Project summary
+
+React 18 + TypeScript SPA for Toon Ranks — a manga/manhwa/manhua community ranking platform.
+- Build tool: Vite
+- Styling: Tailwind CSS (dark mode via `class` strategy)
+- Routing: React Router v6
+- API: axios via `src/api/client.ts` + all API functions in `src/api/manApi.ts`
+- Auth: JWT in localStorage, managed by `UserContext`
+- Testing: Vitest (unit) + Playwright (e2e)
+- Deployed: AWS Amplify — `uat` branch → `uat.toonranks.com` (auto), `main` → `toonranks.com` (manual)
+
+## File map
+
+```
+src/main.tsx          app entry, providers
+src/App.tsx           router + all routes
+src/api/client.ts     axios instance (JWT interceptor, 401 handler)
+src/api/manApi.ts     all API call functions
+src/pages/            one file per route
+src/components/       shared UI components
+src/login/            UserContext + UserProvider
+src/types/types.ts    shared TypeScript types
+src/util/             pure helper functions
+src/config/site.ts    site constants
+e2e/                  Playwright tests
+```
+
+## Non-negotiable rules
+
+- **Never work on `main` or `uat` directly** — feature branches only, merge to `uat` first
+- **All API calls go through `src/api/manApi.ts`** — never raw fetch, never a second axios instance
+- **Auth state from `UserContext`** — never read localStorage for user in components
+- **Role checks use `src/util/roleUtils.ts`** — never inline role string comparisons
+- **No `any` types** without a comment explaining why — TypeScript is strict
+- **Run `npm run lint` and `npm run build`** before finishing any task
+
+## Key domain concepts
+
+- **Series types:** `MANGA`, `MANHWA`, `MANHUA`
+- **Series statuses:** `ONGOING`, `COMPLETE`, `HIATUS`, `UNKNOWN`, `SEASON_END`
+- **User roles:** `GENERAL` (default), `CONTRIBUTOR` (can submit series), `ADMIN` (full access)
+- **Scoring:** 5 categories rated 1–10; `final_score = avg(story, characters, worldbuilding, art, drama_or_fight)`
+- **Theme:** `light` | `dark` — use Tailwind `dark:` classes, controlled by `ThemeContext`
+
+## Where to find things
+
+| Need | Look here |
+|---|---|
+| Full architecture | `docs/ARCHITECTURE.md` |
+| Component/page conventions | `docs/CONVENTIONS.md` |
+| Deployment flow | `docs/DEPLOYMENT.md` |
+| How to run and test | `CONTRIBUTING.md` (or `CLAUDE.md`) |
+
+## What NOT to do
+
+- Don't add routes anywhere except `App.tsx`
+- Don't hardcode the API base URL — always use `import.meta.env.VITE_APP_BASE_URL`
+- Don't store sensitive data in localStorage beyond `token` and `user`
+- Don't use raw `fetch` for API calls
+- Don't write inline styles — use Tailwind classes
+- Don't commit directly to `main` or `uat`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,179 @@
+# Toon Ranks — Frontend (CLAUDE.md)
+
+AI coding assistant entry point. Read this before touching any code.
+
+---
+
+## What this project is
+
+Toon Ranks is a community ranking and review platform for manga, manhwa, and manhua.
+This repo is the **React/TypeScript web frontend** deployed on AWS Amplify.
+
+Key facts:
+- SPA built with Vite + React 18 + TypeScript
+- Styling: Tailwind CSS (dark mode via `class` strategy)
+- Routing: React Router v6 (`BrowserRouter`)
+- API: all calls go through `src/api/client.ts` (axios instance)
+- Auth: JWT stored in `localStorage`, auto-expiry via JWT decode
+- Testing: Vitest (unit) + Playwright (e2e)
+- Deployed on **AWS Amplify** — `uat` branch auto-deploys to `uat.toonranks.com`, `main` deploys to `toonranks.com` via a manual GitHub Action
+
+---
+
+## Repo layout
+
+```
+src/
+  main.tsx          — app entry: wraps in GoogleOAuthProvider, ThemeProvider, UserProvider
+  App.tsx           — BrowserRouter + all Routes defined here
+  App.css           — global styles
+
+  api/
+    client.ts       — axios instance, base URL from VITE_APP_BASE_URL, JWT interceptor, 401 handler
+    manApi.ts       — all API call functions (typed, use client.ts)
+
+  pages/            — one file per route/page
+  components/       — shared UI components
+  login/            — UserContext + UserProvider (auth state)
+  config/
+    site.ts         — site constants (origin, operator name, emails)
+  types/
+    types.ts        — shared TypeScript types (User, SeriesDetailData, etc.)
+  hooks/            — custom React hooks
+  util/             — pure helper functions (auth, avatar, dates, roles, etc.)
+  images/           — static assets
+
+e2e/                — Playwright end-to-end tests
+src/test/           — Vitest setup
+docs/               — Deployment, UAT setup, email aliases
+```
+
+---
+
+## How to run locally
+
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Create local env file
+cp .env.example .env.local     # fill in values — see env vars below
+
+# 3. Start the dev server (hot reload)
+npm run dev
+# → http://localhost:5173
+```
+
+---
+
+## How to run tests
+
+```bash
+# Unit tests (watch mode)
+npm test
+
+# Unit tests (single run — CI mode)
+npm run test:run
+
+# E2E tests (requires dev server running or set PLAYWRIGHT_BASE_URL)
+npm run test:e2e
+
+# Lint
+npm run lint
+
+# Type-check + production build
+npm run build
+```
+
+---
+
+## Environment variables
+
+All env vars must start with `VITE_` to be available in the browser bundle.
+
+| Variable | Required | Description |
+|---|---|---|
+| `VITE_APP_BASE_URL` | **Yes** | Backend API base URL (e.g. `https://www.toonranks.com` or `http://localhost:8000`) |
+| `VITE_GOOGLE_CLIENT_ID` | **Yes** | Google OAuth 2.0 web client ID |
+| `VITE_RECAPTCHA_SITE_KEY` | **Yes** | reCAPTCHA v2 site key |
+| `VITE_APP_ENV` | No | Set to `uat` on the UAT Amplify branch to show the UAT banner (not yet built) |
+
+---
+
+## Critical rules — read before writing any code
+
+1. **Never work directly on `main` or `uat`.** Create a feature branch, merge to `uat` first, then promote to `main` for production. See `docs/DEPLOYMENT.md`.
+2. **Never commit or push** unless the user explicitly asks.
+3. **All API calls go through `src/api/manApi.ts`** — never use raw `fetch` or create a second axios instance. Add new API functions to `manApi.ts`.
+4. **Auth state lives in `UserContext`** (`src/login/UserContext.tsx`). Read it with `useContext(UserContext)`. Never read `localStorage` directly for the user object in components.
+5. **JWT is in `localStorage`** under key `"token"`. The axios interceptor in `client.ts` attaches it automatically. Don't add auth headers manually.
+6. **Role checks use `src/util/roleUtils.ts`** — `isAdminUser(user)`, `canSubmitSeriesUser(user)`. Never compare role strings inline.
+7. **Theme is `light` | `dark`**, controlled by `ThemeContext`. Tailwind `dark:` classes respond to the `dark` class on `<html>`. Never hardcode dark/light colours outside Tailwind classes.
+8. **TypeScript is strict** — no `any` unless truly unavoidable and commented. Run `npm run build` to confirm type-check passes.
+9. **Linter is ESLint** — run `npm run lint` before considering work done.
+10. **New routes** must be added to `App.tsx` — the single source of truth for routing.
+11. **SEO** — every public page should render a `<Seo>` component with appropriate title/description. See `src/components/Seo.tsx`.
+12. **Do not delete commented-out code** unless the user asks — it may be intentional reference.
+
+---
+
+## Key patterns
+
+See `docs/CONVENTIONS.md` for the full reference. Short version:
+
+- **New page** → `src/pages/MyPage.tsx` + route in `App.tsx`
+- **New shared component** → `src/components/MyComponent.tsx`
+- **New API call** → function in `src/api/manApi.ts` using `api` from `client.ts`
+- **New util** → `src/util/myUtil.ts` (pure functions, no React)
+- **Auth-gated UI** → read `user` from `UserContext`, redirect to `/login` if null
+- **Admin-only UI** → gate with `isAdminUser(user)` from `roleUtils.ts`
+- **Loading states** → use shimmer components (`ShimmerBox`, `ShimmerLoader`, `SeriesDetailShimmer`) not spinners
+- **Toasts** → `react-hot-toast` (`toast.success(...)`, `toast.error(...)`)
+- **Markdown rendering** → `<ReactMarkdown>` with `remark-gfm`, `remark-breaks`, `rehype-raw`, `rehype-sanitize`
+
+---
+
+## Page inventory (routes)
+
+| Path | Page | Auth | Notes |
+|---|---|---|---|
+| `/` | `Home` | Public | Rankings homepage with filters |
+| `/series/:id` | `SeriesDetailPage` | Public | Detail + ratings |
+| `/type/:seriesType` | `FilteredSeriesPage` | Public | Filtered rankings (manga/manhwa/manhua) |
+| `/compare` | `ComparePage` | Public | Side-by-side series comparison |
+| `/forum` | `ForumPage` | Public | Forum thread list |
+| `/forum/:id` | `ThreadPage` | Public | Individual thread + posts |
+| `/leaderboard` | `LeaderboardPage` | Public | Cred score rankings |
+| `/user/:username` | `UserProfilePage` | Public | Public profile |
+| `/lists/:token` | `PublicReadingListPage` | Public | Shared reading list |
+| `/login` | `LoginPage` | Public | |
+| `/signup` | `SignupPage` | Public | |
+| `/forgot-password` | `ForgotPasswordPage` | Public | |
+| `/reset-password` | `ResetPasswordPage` | Public | |
+| `/verify-email` | `VerifyEmailPage` | Public | |
+| `/check-your-email` | `CheckYourEmailPage` | Public | |
+| `/account` | `AccountPage` | Auth required | Avatar, username, reading lists, favourites |
+| `/my-lists` | `MyReadingListsPage` | Auth required | |
+| `/my-submissions` | `MySubmissionsPage` | Contributor+ | Series submission management |
+| `/pending-titles` | `PendingTitlesPage` | Admin only | Approve/reject submissions |
+| `/admin/reports` | `AdminReportsPage` | Admin only | Forum report moderation |
+| `/issues` | `IssuesPage` | Admin only | Bug report triage |
+| `/how-rankings-work` | `RankingsInfoPage` | Public | |
+| `/about` | `AboutPage` | Public | |
+| `/contact` | `ContactPage` | Public | |
+| `/report-issue` | `ReportIssuePage` | Public | |
+| `/terms` | `TermsPage` | Public | |
+| `/privacy` | `PrivacyPage` | Public | |
+
+---
+
+## Related repos
+
+| Repo | Purpose | Deployment |
+|---|---|---|
+| `toonranks-frontend` | **This repo** — Vite/React web app | AWS Amplify |
+| `toonranks-backend` | FastAPI REST API | Railway |
+| `toon-ranks-mobile` | React Native / Expo mobile app | EAS (Google Play) |
+
+For the full system picture see `docs/ARCHITECTURE.md`.
+For the deployment process see `docs/DEPLOYMENT.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing (Frontend – React/TypeScript)
+
+## Branch naming
+
+Create a branch before doing any work — **never commit directly to `main` or `uat`**.
+
+Preferred pattern: `frontend-<short-desc>`
+Examples:
+- `frontend-status-filter`
+- `frontend-forum-bookmarks`
+- `frontend-fix-dark-mode-flash`
+
+If you use Jira: `TR-###-<dev>-<short-desc>` (e.g. `TR-12-kin-status-filter`)
+
+---
+
+## Local setup
+
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Create your local env file
+cp .env.example .env.local   # fill in values — see required vars below
+
+# 3. Start the dev server
+npm run dev
+# → http://localhost:5173
+```
+
+### Required environment variables
+
+| Variable | Description |
+|---|---|
+| `VITE_APP_BASE_URL` | Backend API base URL (e.g. `http://localhost:8000` or `https://www.toonranks.com`) |
+| `VITE_GOOGLE_CLIENT_ID` | Google OAuth 2.0 web client ID |
+| `VITE_RECAPTCHA_SITE_KEY` | reCAPTCHA v2 site key |
+
+---
+
+## Running tests
+
+```bash
+# Unit tests (watch mode)
+npm test
+
+# Unit tests (single run — CI mode)
+npm run test:run
+
+# E2E tests
+npm run test:e2e
+
+# Lint
+npm run lint
+
+# Type-check + production build
+npm run build
+```
+
+---
+
+## Deployment flow
+
+Feature branches merge to **`uat`** first (auto-deploys to `uat.toonranks.com`).
+After testing on UAT, `uat` is merged to `main` and the "Deploy to Production" GitHub Action
+is triggered manually.
+
+See `docs/DEPLOYMENT.md` for the full process.
+
+---
+
+## Before opening a PR
+
+- [ ] Branch is off `main`, not committed to `main` or `uat` directly
+- [ ] `npm run lint` passes with no errors
+- [ ] `npm run build` succeeds (confirms TypeScript types pass)
+- [ ] `npm run test:run` passes
+- [ ] New page has a route entry in `src/App.tsx`
+- [ ] New API call is in `src/api/manApi.ts` (not inline in a component)
+- [ ] Dark mode tested (toggle theme and verify)
+- [ ] No hardcoded API URLs — using `import.meta.env.VITE_APP_BASE_URL`
+
+---
+
+## Key reference docs
+
+| Doc | What it covers |
+|---|---|
+| `CLAUDE.md` | AI assistant entry point — project overview, rules, patterns, page inventory |
+| `AGENTS.md` | Universal agent instructions (Cursor, Copilot, Windsurf) |
+| `docs/ARCHITECTURE.md` | System overview, state management, API layer, auth flow, theming |
+| `docs/CONVENTIONS.md` | Coding patterns — pages, components, API calls, auth, theming, markdown |
+| `docs/DEPLOYMENT.md` | Release process — UAT, production, GitHub Actions |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,152 @@
+# Architecture — Toon Ranks Frontend
+
+## System overview
+
+```
+User's browser
+  │
+  ▼
+Cloudflare (DNS + cache proxy)
+  │
+  ▼
+AWS CloudFront (via Amplify)
+  │
+  ├── Static assets (JS bundle, CSS, images) — served from CDN edge
+  │
+  └── API calls (XHR/fetch via axios)
+        │
+        ▼
+      FastAPI backend (Railway)
+        │
+        ▼
+      PostgreSQL (man_review schema)
+      AWS S3 (images)
+      SendGrid (email)
+      Google OAuth (id_token verify)
+```
+
+## Environments
+
+| Environment | Branch | URL | How it deploys |
+|---|---|---|---|
+| UAT | `uat` | `https://uat.toonranks.com` | Auto on every push/merge to `uat` |
+| Production | `main` | `https://toonranks.com` | Manual — "Deploy to Production" GitHub Action |
+
+Both environments share the **same backend and database**. UAT is frontend-only staging.
+See `docs/DEPLOYMENT.md` for the full release process.
+
+## Application bootstrap
+
+```
+index.html
+  └── src/main.tsx
+        ├── GoogleOAuthProvider   — wraps app with Google OAuth context
+        ├── ThemeProvider         — reads/writes theme from localStorage, sets dark class on <html>
+        ├── UserProvider          — reads JWT + user from localStorage on mount, schedules auto-logout
+        └── <App />
+              └── SearchProvider
+                    └── BrowserRouter
+                          ├── Header
+                          ├── <Routes> (all page components)
+                          └── Footer
+```
+
+## State management
+
+There is no Redux or Zustand. State is managed with:
+
+| Concern | Mechanism |
+|---|---|
+| Auth (user + token) | `UserContext` — React Context, backed by `localStorage` |
+| Theme (light/dark) | `ThemeContext` — React Context, backed by `localStorage` |
+| Search input | `SearchContext` — React Context (header search bar shared across pages) |
+| Server data | Local component state + `useEffect` data fetching |
+| Notifications | Polled per-page (no WebSocket) |
+| Toasts | `react-hot-toast` (imperative API) |
+
+## API layer
+
+All backend communication goes through two files:
+
+### `src/api/client.ts`
+- Creates a single axios instance with `baseURL: import.meta.env.VITE_APP_BASE_URL`
+- **Request interceptor:** attaches `Authorization: Bearer <token>` from localStorage (skipped on public auth routes)
+- **Response interceptor:** on 401 from non-auth routes → clears localStorage + hard-redirects to `/login`; on auth routes → lets the error propagate so the login page can show "Invalid credentials"
+- Exports `isRequestCanceled()` for AbortController cleanup
+
+### `src/api/manApi.ts`
+- Typed functions for every backend endpoint
+- All functions use the `api` instance from `client.ts`
+- This is the **only** place where API URLs are written — never call `api` directly from components
+
+## Auth flow
+
+```
+Login / Google OAuth
+  │
+  ▼
+Backend returns { access_token, user }
+  │
+  ▼
+localStorage.setItem("token", access_token)
+localStorage.setItem("user", JSON.stringify(user))
+UserContext.setUser(user)
+scheduleLogoutAtJwtExp(setUser, token)  ← decodes JWT exp, sets a setTimeout
+  │
+  ▼
+Every request → axios interceptor attaches token automatically
+  │
+  ▼
+On 401 (non-auth route) → hardLogout() → clears storage → redirect /login
+On JWT expiry → scheduleLogoutAtJwtExp fires → forceLogout(setUser) → clears storage
+On other tab logout → storage event listener → forceLogout(setUser)
+```
+
+## Routing
+
+All routes are defined in `src/App.tsx`. React Router v6 `<Routes>` with `<Route>` elements.
+No lazy loading currently — all pages are eagerly bundled.
+
+Route guarding is done at the component level — pages redirect to `/login` if `user` is null,
+or render nothing / redirect if the role is insufficient.
+
+## Theming
+
+- Tailwind `darkMode: "class"` — the `dark` class on `<html>` activates dark styles
+- `ThemeProvider` reads the stored preference from `localStorage` on mount
+- Falls back to `prefers-color-scheme` if no preference is stored
+- `useTheme()` hook exposes `{ theme, setTheme, toggleTheme }`
+- Theme toggle is in the `Header` component
+
+## Markdown rendering
+
+Forum posts and thread content are stored and transmitted as raw markdown.
+Rendering uses the `react-markdown` pipeline:
+
+```
+content_markdown (raw string)
+  │
+  ▼
+<ReactMarkdown
+  remarkPlugins={[remarkGfm, remarkBreaks]}
+  rehypePlugins={[rehypeRaw, rehypeRawSanitize]}
+>
+```
+
+`rehype-sanitize` prevents XSS from `<img>` tags and raw HTML injected by users.
+
+## Image handling
+
+- Series covers and detail banners: S3 URLs stored in the backend, rendered as `<img>` tags
+- User avatars: S3 URL or colour preset (`blue` | `emerald` | `amber`), rendered by `<UserAvatar>`
+- Dominant colour extraction for series cards: `colorthief` library (`src/util/getDominantColor.ts`)
+- Forum media: uploaded via `POST /forum/media/upload`, stored on S3, referenced by URL in markdown
+
+## Build output
+
+```bash
+npm run build   # tsc -b && vite build
+```
+
+Output goes to `dist/`. Amplify picks up `dist/` and serves it from CloudFront.
+The `amplify.yml` in the repo root configures the build command and artifact path.

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,292 @@
+# Conventions — Toon Ranks Frontend
+
+Patterns used throughout this codebase. Follow these when adding or editing code.
+
+---
+
+## Adding a new page
+
+1. Create `src/pages/MyNewPage.tsx`
+2. Add the route in `src/App.tsx`:
+   ```tsx
+   import MyNewPage from "./pages/MyNewPage";
+   // inside <Routes>:
+   <Route path="/my-path" element={<MyNewPage />} />
+   ```
+3. If the page is public-facing, add a `<Seo>` component at the top of the render
+4. If auth-gated, redirect to `/login` when `user` is null (see auth pattern below)
+
+---
+
+## Adding a new API call
+
+All API functions live in `src/api/manApi.ts`. Add yours there:
+
+```ts
+// src/api/manApi.ts
+export async function getMyThing(id: number): Promise<MyThingType> {
+  const res = await api.get<MyThingType>(`/my-thing/${id}`);
+  return res.data;
+}
+
+export async function createMyThing(payload: MyThingCreate): Promise<MyThingType> {
+  const res = await api.post<MyThingType>("/my-thing/", payload);
+  return res.data;
+}
+```
+
+Never call `api` directly inside a component or `import axios from 'axios'` in a page.
+
+---
+
+## Auth-gated pages
+
+Read the user from `UserContext` and redirect if null:
+
+```tsx
+import { useContext } from "react";
+import { useNavigate } from "react-router-dom";
+import { UserContext } from "../login/UserContext";
+
+export default function MyProtectedPage() {
+  const { user } = useContext(UserContext);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user) navigate("/login", { replace: true });
+  }, [user, navigate]);
+
+  if (!user) return null;
+  // render page ...
+}
+```
+
+---
+
+## Role checks
+
+Always use the helpers from `src/util/roleUtils.ts`:
+
+```ts
+import { isAdminUser, canSubmitSeriesUser } from "../util/roleUtils";
+
+// In JSX:
+{isAdminUser(user) && <AdminPanel />}
+{canSubmitSeriesUser(user) && <SubmitButton />}
+```
+
+Never write `user?.role === "ADMIN"` inline — use the helpers.
+
+---
+
+## Data fetching pattern
+
+Use `useEffect` + local state. Cancel on unmount using `AbortController`:
+
+```tsx
+const [data, setData] = useState<MyType | null>(null);
+const [loading, setLoading] = useState(true);
+const [error, setError] = useState<string | null>(null);
+
+useEffect(() => {
+  const controller = new AbortController();
+
+  (async () => {
+    try {
+      setLoading(true);
+      const result = await getMyThing(id);
+      if (!controller.signal.aborted) setData(result);
+    } catch (err) {
+      if (!isRequestCanceled(err)) setError("Failed to load data");
+    } finally {
+      if (!controller.signal.aborted) setLoading(false);
+    }
+  })();
+
+  return () => controller.abort();
+}, [id]);
+```
+
+Import `isRequestCanceled` from `src/api/client.ts` to safely ignore abort errors.
+
+---
+
+## Loading states
+
+Use shimmer components, not spinners:
+
+```tsx
+import ShimmerBox from "../components/ShimmerBox";
+import ShimmerLoader from "../components/ShimmerLoader";
+import SeriesDetailShimmer from "../components/SeriesDetailShimmer";
+import ReadingListShimmers from "../components/ReadingListShimmers";
+
+if (loading) return <ShimmerLoader />;
+```
+
+---
+
+## Toast notifications
+
+```tsx
+import toast from "react-hot-toast";
+
+toast.success("Saved!");
+toast.error("Something went wrong.");
+```
+
+`react-hot-toast` is globally mounted — no provider needed per-page.
+
+---
+
+## Theming
+
+Always use Tailwind `dark:` variants. Never hardcode dark/light colours:
+
+```tsx
+// ✅ Correct
+<div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+
+// ❌ Wrong — breaks dark mode
+<div style={{ backgroundColor: "#ffffff" }}>
+```
+
+Access theme programmatically:
+```tsx
+import { useTheme } from "../components/useTheme";
+const { theme, toggleTheme } = useTheme();
+```
+
+---
+
+## SEO / meta tags
+
+Every public page should include a `<Seo>` component:
+
+```tsx
+import Seo from "../components/Seo";
+
+// in render:
+<Seo
+  title="Page Title | Toon Ranks"
+  description="Short description for search engines."
+/>
+```
+
+`Seo` uses `react-helmet` internally.
+
+---
+
+## Markdown rendering
+
+For user-generated content (forum posts, thread content):
+
+```tsx
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
+
+<ReactMarkdown
+  remarkPlugins={[remarkGfm, remarkBreaks]}
+  rehypePlugins={[rehypeRaw, rehypeSanitize]}
+>
+  {content}
+</ReactMarkdown>
+```
+
+Always include `rehype-sanitize` for user content to prevent XSS.
+
+---
+
+## User avatar
+
+Use the `<UserAvatar>` component — never render avatar URLs directly:
+
+```tsx
+import UserAvatar from "../components/UserAvatar";
+
+<UserAvatar
+  avatarUrl={user.avatar_url}
+  avatarPreset={user.avatar_preset}
+  username={user.username}
+  size={40}
+/>
+```
+
+---
+
+## Utility functions
+
+| Function | File | Purpose |
+|---|---|---|
+| `isAdminUser(user)` | `util/roleUtils.ts` | Role check |
+| `canSubmitSeriesUser(user)` | `util/roleUtils.ts` | Role check |
+| `formatScore(score)` | `util/formatScore.ts` | Format numeric rating |
+| `getAvatarDisplay(user)` | `util/avatar.ts` | Resolve avatar URL or preset |
+| `formatDate(dt)` | `util/dateUtils.ts` | Human-readable date |
+| `scheduleLogoutAtJwtExp(setUser, token)` | `util/authUtils.ts` | JWT expiry timer |
+| `forceLogout(setUser)` | `util/authUtils.ts` | Clear session + redirect |
+| `getDominantColor(imgEl)` | `util/getDominantColor.ts` | ColorThief wrapper |
+
+---
+
+## TypeScript
+
+Key types are in `src/types/types.ts`:
+
+```ts
+User            — id, username, role, avatar_url, avatar_preset
+UserRole        — "ADMIN" | "GENERAL" | "CONTRIBUTOR"
+AvatarPreset    — "blue" | "emerald" | "amber"
+SeriesDetailData — full series detail shape from the backend
+```
+
+Avoid `any`. When a third-party type is missing, write a local declaration file in `src/types/`.
+
+---
+
+## Environment variables
+
+Access via `import.meta.env.VITE_*` — never `process.env`:
+
+```ts
+const baseUrl = import.meta.env.VITE_APP_BASE_URL;
+const googleClientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+const recaptchaKey = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
+```
+
+Never hardcode URLs. Never commit `.env` files.
+
+---
+
+## New shared component checklist
+
+1. Create `src/components/MyComponent.tsx`
+2. Export as a named export (`export function MyComponent(...)`) or default
+3. Props interface named `MyComponentProps` defined in the same file
+4. Use Tailwind classes — no inline styles
+5. Support dark mode via `dark:` classes
+6. If it uses context, import from the appropriate context file
+
+---
+
+## Linting and type checking
+
+```bash
+npm run lint        # ESLint
+npm run build       # tsc -b + vite build (catches type errors)
+```
+
+Both must pass before a PR is ready. The CI pipeline runs both.
+
+---
+
+## Testing
+
+- **Unit tests:** Vitest + Testing Library. File pattern: `*.test.tsx` or `*.test.ts` alongside the source file.
+- **E2E tests:** Playwright, in `e2e/`.
+- Tests must not call the real backend — mock API responses.
+- Run unit tests: `npm run test:run`
+- Run E2E: `npm run test:e2e`


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` — primary AI agent entry point with project overview, env vars, hard rules, and full page/route inventory
- Adds `AGENTS.md` — universal agent instructions for Cursor, Copilot, Windsurf
- Adds `.cursorrules` — Cursor-native project rules and styling constraints
- Adds `docs/ARCHITECTURE.md` — system diagram, environment table, bootstrap tree, state management, API layer, auth flow, theming, markdown pipeline
- Adds `docs/CONVENTIONS.md` — new page/component/API call patterns, auth guards, data fetching, loading states, toasts, theming, SEO, TypeScript guidance
- Adds `CONTRIBUTING.md` — replaces hidden `.CONTRIBUTING.md` with full local setup, test commands, deployment flow summary, pre-PR checklist

## Test plan
- [ ] No code changes — docs only, no tests needed
- [ ] Verify files appear correctly on GitHub after merge