### PR TITLE
Uat

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -5,6 +5,9 @@ React 18 + TypeScript SPA. Vite build tool. Tailwind CSS (dark mode: class). Rea
 Deployed on AWS Amplify. Backend is a separate FastAPI repo (toonranks-backend).
 
 ## Hard rules
+- **Read CONSTRAINTS.md** — it defines the full workflow and handoff requirements
+- Never commit or push without explicit instruction from the owner
+- Always end every task with: numbered UI test steps + one-line commit message + short PR description
 - Never commit directly to `main` or `uat` — feature branches only, merge to `uat` first
 - All API calls go through `src/api/manApi.ts` using the axios instance from `src/api/client.ts`
 - Auth state lives in `UserContext` (src/login/) — never read localStorage for user in components

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ e2e/                  Playwright tests
 
 ## Non-negotiable rules
 
+> See `CONSTRAINTS.md` for the full workflow. Key points repeated here:
+
+- **Never commit or push without explicit instruction** — wait to be told; finishing a task does not mean commit
+- **Always end every task with** numbered UI test steps + one-line commit message + short PR description
 - **Never work on `main` or `uat` directly** — feature branches only, merge to `uat` first
 - **All API calls go through `src/api/manApi.ts`** — never raw fetch, never a second axios instance
 - **Auth state from `UserContext`** — never read localStorage for user in components

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 AI coding assistant entry point. Read this before touching any code.
 
+> ⚠️ **Read `CONSTRAINTS.md` first.** It defines the non-negotiable workflow rules:
+> never commit/push without explicit instruction, always end every task with UI test
+> steps + a commit message + a PR description, one branch per task.
+
 ---
 
 ## What this project is
@@ -102,10 +106,13 @@ All env vars must start with `VITE_` to be available in the browser bundle.
 
 ## Critical rules — read before writing any code
 
-1. **Never work directly on `main` or `uat`.** Create a feature branch, merge to `uat` first, then promote to `main` for production. See `docs/DEPLOYMENT.md`.
-2. **Never commit or push** unless the user explicitly asks.
-3. **All API calls go through `src/api/manApi.ts`** — never use raw `fetch` or create a second axios instance. Add new API functions to `manApi.ts`.
-4. **Auth state lives in `UserContext`** (`src/login/UserContext.tsx`). Read it with `useContext(UserContext)`. Never read `localStorage` directly for the user object in components.
+> Full workflow constraints are in `CONSTRAINTS.md`. The short version:
+
+1. **Never commit or push without explicit instruction from the owner.** Finishing a task does not mean you commit. Wait to be told.
+2. **Always end every task with:** numbered UI test steps, a one-line commit message, and a short GitHub PR description. No exceptions.
+3. **Never work directly on `main` or `uat`.** Create a feature branch, merge to `uat` first, then promote to `main` for production. See `docs/DEPLOYMENT.md`.
+4. **All API calls go through `src/api/manApi.ts`** — never use raw `fetch` or create a second axios instance. Add new API functions to `manApi.ts`.
+5. **Auth state lives in `UserContext`** (`src/login/UserContext.tsx`). Read it with `useContext(UserContext)`. Never read `localStorage` directly for the user object in components.
 5. **JWT is in `localStorage`** under key `"token"`. The axios interceptor in `client.ts` attaches it automatically. Don't add auth headers manually.
 6. **Role checks use `src/util/roleUtils.ts`** — `isAdminUser(user)`, `canSubmitSeriesUser(user)`. Never compare role strings inline.
 7. **Theme is `light` | `dark`**, controlled by `ThemeContext`. Tailwind `dark:` classes respond to the `dark` class on `<html>`. Never hardcode dark/light colours outside Tailwind classes.

--- a/CONSTRAINTS.md
+++ b/CONSTRAINTS.md
@@ -1,0 +1,105 @@
+# AI Assistant Constraints — Toon Ranks Frontend
+
+These rules apply to every AI assistant working in this repository without exception.
+They are repeated in `CLAUDE.md`, `AGENTS.md`, and `.cursorrules` — if you are reading
+any of those files, these constraints still apply.
+
+---
+
+## Workflow — how work gets shipped
+
+```
+AI creates feature branch
+        │
+        ▼
+AI does the work on that branch
+        │
+        ▼
+AI hands off:
+  1. UI / emulator test steps (what to click, what to expect)
+  2. Short commit message
+  3. Short GitHub PR description
+        │
+        ▼
+Owner reviews — ONLY commits and pushes when explicitly told to
+        │
+        ▼
+Owner creates PR → uat
+        │
+        ▼
+Auto-deploys to uat.toonranks.com — owner tests
+        │
+        ▼
+PR uat → main
+        │
+        ▼
+GitHub Actions → "Deploy to Production" (manual trigger, type "deploy")
+        │
+        ▼
+Back-merge main → uat to keep branches even
+```
+
+---
+
+## Hard constraints
+
+### 1. Never commit or push without explicit instruction
+Do not run `git commit`, `git push`, `git merge`, or open a PR unless the owner
+explicitly says "commit", "push", or "commit and push". Completing a task does
+**not** imply permission to commit. Always wait to be asked.
+
+### 2. Always provide a handoff at the end of every task
+When you finish work on a branch, always end your response with:
+
+**UI test steps** — numbered steps the owner can follow to verify the change
+works in the browser. Include:
+- Where to navigate
+- What to interact with
+- What the expected outcome is
+
+Example:
+```
+1. Go to https://uat.toonranks.com
+2. Click the cookie banner "Accept" button
+3. Expected: banner disappears and does not reappear on refresh
+4. Click "Manage" instead — expected: preferences modal opens
+```
+
+**Commit message** — one line, imperative, under 72 characters:
+```
+feat: add cookie consent banner with localStorage persistence
+```
+
+**GitHub PR description** — short summary + test plan checklist:
+```
+## Summary
+- Adds cookie consent banner (accept / manage preferences)
+- Persists choice to localStorage — does not re-show after accept
+- Updates Privacy Policy to mention ad cookies
+
+## Test plan
+- [ ] Banner appears on first visit
+- [ ] Accept hides banner permanently
+- [ ] Manage opens preferences modal
+- [ ] Privacy Policy mentions advertising cookies
+```
+
+### 3. One branch per task
+Never mix unrelated changes on the same branch. If you notice something else
+that needs fixing while working, flag it as a follow-up, do not fix it inline.
+
+### 4. Never work directly on `main` or `uat`
+All work goes on a feature branch named `frontend-<short-desc>`. The owner
+merges to `uat` via a PR after reviewing.
+
+### 5. Ask before assuming on anything ambiguous
+If a requirement is unclear, ask one focused question before writing code.
+Do not make assumptions and build the wrong thing.
+
+---
+
+## Branch naming
+
+`frontend-<short-desc>`
+
+Examples: `frontend-cookie-consent`, `frontend-fix-dark-flash`, `frontend-adsense-ready`


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md, AGENTS.md, .cursorrules — AI assistant entry points
- Adds CONSTRAINTS.md — workflow rules (no commit without instruction, always hand off test steps + commit message + PR description)
- Adds docs/ARCHITECTURE.md, docs/CONVENTIONS.md
- Updates docs/DEPLOYMENT.md — adds step 5 (back-merge main → uat) and gotcha entry
- Adds CONTRIBUTING.md replacing the hidden .CONTRIBUTING.md

## Test plan
- [ ] Docs only — no code changes, no tests needed
- [ ] Verify all files appear on GitHub after merge