### PR TITLE
feat: add Google AdSense verification script

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,6 +81,10 @@
     </script>
 
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+
+    <!-- Google AdSense — ownership verification + ad serving -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5886971570640795"
+        crossorigin="anonymous"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Adds Google AdSense script tag to index.html <head>
- Required for site ownership verification and ad serving (ca-pub-5886971570640795)

## Test plan
- [ ] View page source on UAT — AdSense script present in <head>
- [ ] Verify in AdSense console and request review