### PR TITLE
Uat

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -106,10 +106,22 @@ const Header = () => {
     setSelectedCategory(DEFAULT_LABEL);
   };
 
+  // When searching from a category page (/type/<TYPE>), keep that category
+  // context so results show their within-category rank. From anywhere else,
+  // search lands on the All rankings page (home).
+  const searchBasePath = () => {
+    const path = location.pathname || "/";
+    if (path.startsWith("/type/")) {
+      const seg = path.split("/")[2];
+      if (seg) return `/type/${seg}`;
+    }
+    return "/";
+  };
+
   const handleSearchSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchTerm.trim()) {
-      navigate(`/?search=${encodeURIComponent(searchTerm)}`);
+      navigate(`${searchBasePath()}?search=${encodeURIComponent(searchTerm)}`);
       setMobileMenuOpen(false);
       setMobileAccountOpen(false);
     }
@@ -121,7 +133,7 @@ const Header = () => {
     if (!value) return;
     setSearchTerm(value);
     closeMobileSearch();
-    navigate(`/?search=${encodeURIComponent(value)}`);
+    navigate(`${searchBasePath()}?search=${encodeURIComponent(value)}`);
   };
 
   const handleMobileSearchSelect = (item: RankedSeries) => {
@@ -568,7 +580,9 @@ const Header = () => {
                         if (!value) return;
                         setSearchTerm(value);
                         closeMobileSearch();
-                        navigate(`/?search=${encodeURIComponent(value)}`);
+                        navigate(
+                          `${searchBasePath()}?search=${encodeURIComponent(value)}`
+                        );
                       }}
                       className="mt-3 w-full rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 dark:bg-[linear-gradient(135deg,_#315ff4,_#2347c5)] dark:hover:brightness-110"
                     >


### PR DESCRIPTION
## Summary
- Nav search previously always navigated to "/?search=" (the All page), discarding the selected category — so searching while a Manga/Manhwa/Manhua category was selected showed the global rank instead of the within-category rank
- Adds searchBasePath(): searching from a /type/<TYPE> page now stays in that category (/type/<TYPE>?search=…), so results show their within-category rank (backend type-scoping already merged)
- Applies to all three search-submit paths (desktop, mobile submit, mobile "see all results")
- Searching from anywhere else still lands on the All page (unchanged)

## Test plan
- [ ] Browse /type/MANHWA → Solo Leveling shows #6
- [ ] Search "solo leveling" while on Manhwa → stays on Manhwa, shows #6 (not #12)
- [ ] Search "solo leveling" from home (All) → shows #12
- [ ] Mobile search keeps category context too
- [ ] Search from an unrelated page → lands on All results
- [ ] tsc + eslint pass