### PR TITLE
ci: auto-purge Cloudflare cache after production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -82,3 +82,25 @@ jobs:
           done
           echo "::error::Timed out waiting for Amplify job $JOB_ID."
           exit 1
+
+      # Amplify/CloudFront now has the new files, but Cloudflare (the authoritative
+      # proxy in front of the site) may still serve the previous build. Purge it so
+      # visitors — and Googlebot — immediately get the new deploy. This automates
+      # the recurring "blank screen / stale 404s after deploy" fix.
+      - name: Purge Cloudflare cache
+        env:
+          CF_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          echo "Purging Cloudflare cache for zone $CF_ZONE_ID..."
+          RESPONSE=$(curl -s -X POST \
+            "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/purge_cache" \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}')
+          echo "$RESPONSE"
+          if [ "$(echo "$RESPONSE" | jq -r '.success')" != "true" ]; then
+            echo "::error::Cloudflare cache purge failed."
+            exit 1
+          fi
+          echo "✅ Cloudflare cache purged."

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -59,8 +59,9 @@ until you promote.
   ship prod by themselves. `uat` auto-build stays ON.
 - **`.github/workflows/deploy-production.yml`** — manual (`workflow_dispatch`)
   production release. Assumes the AWS OIDC role (`vars.AWS_ROLE_TO_ASSUME`) and
-  calls `aws amplify start-job --branch-name main --job-type RELEASE`, then waits
-  for the job to finish. There is intentionally **no `environment:`** on the job
+  calls `aws amplify start-job --branch-name main --job-type RELEASE`, waits for the
+  job to finish, then **purges the Cloudflare cache** (`purge_everything`) so the new
+  build is served immediately. There is intentionally **no `environment:`** on the job
   (see gotchas).
 - **`.github/workflows/frontend-ci.yml`** — runs on PRs/pushes to `main` and
   `uat`. Its "Amplify deployment" wait job only runs on **push to `uat`** (the
@@ -86,8 +87,11 @@ until you promote.
 - **IAM permission:** the role needs `amplify:StartJob` (plus `GetJob` /
   `ListJobs` for polling). Already granted on
   `GitHubActionsAmplifyDeployReadOnly-ToonRanks`.
-- **Cloudflare cache:** after a prod deploy, if a stale build is served, purge the
-  Cloudflare cache (the classic "blank screen after deploy" symptom).
+- **Cloudflare cache:** the "Deploy to Production" workflow now **purges Cloudflare
+  automatically** as its last step (after the Amplify release succeeds), using the
+  `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ZONE_ID` repo secrets. This fixes the classic
+  "blank screen / stale 404s after deploy" symptom without a manual purge. If you ever
+  deploy outside this workflow, purge Cloudflare by hand.
 
 ## Hotfixes
 


### PR DESCRIPTION
## Summary
- deploy-production.yml now purges the Cloudflare cache (purge_everything) after the Amplify release succeeds, so the new build is served immediately to users and Googlebot
- Uses CLOUDFLARE_API_TOKEN + CLOUDFLARE_ZONE_ID repo secrets (cache-purge-scoped token)
- Fails the deploy if the purge call doesn't succeed
- Docs updated: Cloudflare purge is now automatic

## Test plan
- [ ] Next prod deploy: "Purge Cloudflare cache" step runs after Amplify succeeds and logs success:true
- [ ] Site serves the new build with no manual purge
- [ ] Wrong creds would fail the step loudly