### PR TITLE
feat(design): phase 1 polish — fonts, lazy covers, card cleanup, nav/…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "toonranks-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/manrope": "^5.2.8",
         "@heroicons/react": "^2.2.0",
         "@react-oauth/google": "^0.12.2",
         "@react-router/serve": "^7.17.0",
@@ -1363,6 +1365,24 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/manrope": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/manrope/-/manrope-5.2.8.tgz",
+      "integrity": "sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@heroicons/react": {
@@ -10340,6 +10360,16 @@
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
       "dev": true
+    },
+    "@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ=="
+    },
+    "@fontsource-variable/manrope": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/manrope/-/manrope-5.2.8.tgz",
+      "integrity": "sha512-nc9lOuCRz73UHnovDE2bwXUdghE2SEOc7Aii0qGe3CLyE03W1a7VnY5Z6euRiapiKbCkGS+eXbY3s/kvWeGeSw=="
     },
     "@heroicons/react": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/manrope": "^5.2.8",
     "@heroicons/react": "^2.2.0",
     "@react-oauth/google": "^0.12.2",
     "@react-router/serve": "^7.17.0",

--- a/src/components/FilterSelect.tsx
+++ b/src/components/FilterSelect.tsx
@@ -51,7 +51,7 @@ export default function FilterSelect({ label, value, options, onChange }: Props)
         aria-expanded={open}
         className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 dark:border-[#3a3028] dark:bg-[#1e1712] dark:text-slate-200 dark:hover:bg-[#241d19] sm:py-2"
       >
-        <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-400 dark:text-slate-500">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.16em] text-slate-500 dark:text-slate-400">
           {label}
         </span>
         {selected?.dot ? (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -55,13 +55,8 @@ const Footer = () => {
                 </a>
               </li>
               <li>
-                <a href="/issues" className={footerLinkClass}>
-                  Issues
-                </a>
-              </li>
-              <li>
                 <a href="/how-rankings-work" className={footerLinkClass}>
-                  Ranks
+                  How Rankings Work
                 </a>
               </li>
               <li>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -284,7 +284,7 @@ const Header = () => {
               Forum
             </NavLink>
             <NavLink to="/leaderboard" className={desktopNavLink}>
-              Rankers
+              Leaderboard
             </NavLink>
           </nav>
         </div>
@@ -614,7 +614,7 @@ const Header = () => {
                   { to: "/type/MANGA", label: "Manga" },
                   { to: "/type/MANHUA", label: "Manhua" },
                   { to: "/forum", label: "Forum" },
-                  { to: "/leaderboard", label: "Rankers" },
+                  { to: "/leaderboard", label: "Leaderboard" },
                 ].map((item) => (
                   <NavLink
                     key={item.label}

--- a/src/components/ManCard.tsx
+++ b/src/components/ManCard.tsx
@@ -90,6 +90,12 @@ const ManCard = ({
   const showVotes = votes >= 10;
   const showListBtn = !!onAddToReadingList;
   const showCompareBtn = !!onCompareToggle;
+  // Many series have the same person as author and artist; showing the name
+  // twice is noise, so collapse to a single row in that case.
+  const sameCreator =
+    !!author &&
+    !!artist &&
+    author.trim().toLowerCase() === artist.trim().toLowerCase();
 
   const ListButton = () => (
     <button
@@ -153,6 +159,8 @@ const ManCard = ({
               ref={imgRef}
               src={coverUrl}
               alt={`Cover for ${title}`}
+              loading="lazy"
+              decoding="async"
               onLoad={() => setImageLoaded(true)}
               className={`h-full w-full object-cover transition duration-500 ${
                 imageLoaded
@@ -196,7 +204,7 @@ const ManCard = ({
             {author && (
               <p
                 className="flex items-center gap-1 text-[13px] text-gray-600 dark:text-slate-300 sm:gap-1.5 sm:text-sm"
-                title={author}
+                title={sameCreator ? `Author & Artist: ${author}` : author}
               >
                 <Pencil className="h-4 w-4 flex-shrink-0 text-gray-700 dark:text-slate-400" />
                 <span
@@ -208,7 +216,7 @@ const ManCard = ({
               </p>
             )}
 
-            {artist && (
+            {artist && !sameCreator && (
               <p
                 className="flex items-center gap-1 text-[13px] text-gray-600 dark:text-slate-300 sm:gap-1.5 sm:text-sm"
                 title={artist}
@@ -238,10 +246,10 @@ const ManCard = ({
                     onCompareToggle?.();
                   }}
                   title="Select to Compare"
-                  className={`rounded-full px-2 py-0.5 text-[11px] font-semibold sm:text-xs ${
+                  className={`rounded-full px-2 py-0.5 text-[11px] font-semibold transition sm:text-xs ${
                     isCompared
                       ? "bg-blue-600 text-white"
-                      : "bg-gray-200 text-gray-700 dark:bg-[linear-gradient(145deg,_rgba(35,28,24,0.95),_rgba(24,19,16,0.95))] dark:text-slate-200"
+                      : "border border-gray-300 bg-transparent text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:border-[#3a3028] dark:text-slate-400 dark:hover:bg-[#241d19] dark:hover:text-slate-200"
                   }`}
                 >
                   {isCompared ? "✓" : "+"} Compare
@@ -258,10 +266,10 @@ const ManCard = ({
                       onCompareToggle?.();
                     }}
                     title="Select to Compare"
-                    className={`rounded-full px-2 py-0.5 text-[11px] font-semibold sm:text-xs ${
+                    className={`rounded-full px-2 py-0.5 text-[11px] font-semibold transition sm:text-xs ${
                       isCompared
                         ? "bg-blue-600 text-white"
-                        : "bg-gray-200 text-gray-700 dark:bg-[linear-gradient(145deg,_rgba(35,28,24,0.95),_rgba(24,19,16,0.95))] dark:text-slate-200"
+                        : "border border-gray-300 bg-transparent text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:border-[#3a3028] dark:text-slate-400 dark:hover:bg-[#241d19] dark:hover:text-slate-200"
                     }`}
                   >
                     {isCompared ? "✓" : "+"} Compare

--- a/src/components/RankingsToolbar.tsx
+++ b/src/components/RankingsToolbar.tsx
@@ -103,7 +103,7 @@ export default function RankingsToolbar({
             {contextLabel}
           </span>
           <span className="inline-flex items-center rounded-full bg-white px-2.5 py-1 text-xs font-medium text-slate-600 ring-1 ring-inset ring-slate-200 dark-theme-chip dark:text-slate-300 sm:px-3 sm:py-1.5 sm:text-sm">
-            {loadedCount} loaded
+            Showing {loadedCount} series
           </span>
         </div>
         {rightSlot}

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,8 @@
+/* Self-hosted variable fonts (no external requests): Inter for body/UI,
+   Manrope for headings. Wired into Tailwind via fontFamily in tailwind.config.js. */
+@import "@fontsource-variable/inter";
+@import "@fontsource-variable/manrope";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -9,7 +14,15 @@ body,
 }
 
 body {
-  @apply bg-slate-50 text-slate-900 antialiased transition-colors dark:bg-[#15110f] dark:text-[#f4efe8];
+  @apply bg-slate-50 font-sans text-slate-900 antialiased transition-colors dark:bg-[#15110f] dark:text-[#f4efe8];
+}
+
+/* Headings use the display font with slightly tighter tracking for a more
+   intentional, modern feel. Components can override per-element if needed. */
+h1,
+h2,
+h3 {
+  @apply font-display tracking-tight;
 }
 
 @layer components {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,28 @@ export default {
   darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        // Body/UI font: Inter (loaded via @fontsource-variable/inter in index.css)
+        sans: [
+          "Inter Variable",
+          "system-ui",
+          "Avenir",
+          "Helvetica",
+          "Arial",
+          "sans-serif",
+        ],
+        // Headings font: Manrope — slightly rounder/friendlier, suits the comics
+        // community feel. Applied to h1-h3 globally in index.css; available as
+        // `font-display` for one-off use.
+        display: [
+          "Manrope Variable",
+          "Inter Variable",
+          "system-ui",
+          "sans-serif",
+        ],
+      },
+    },
   },
   plugins: [typography],
 };


### PR DESCRIPTION
Design polish phase 1 (no functional changes): self-hosted Inter (body) + Manrope (headings) typography; lazy-loaded cover images; ManCard cleanup (collapse duplicate author/artist row, ghost-style Compare button); "25 loaded" → "Showing N series"; filter label contrast bump; footer cleanup (removed admin Issues link, clearer How Rankings Work label); nav renamed Rankers → Leaderboard. Checks: tsc/lint clean, unit 21/21, e2e 6/6.