### PR TITLE
feat(design): phase 2 brand — vector wordmark logo, logged-out homepa…

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,7 +12,7 @@ import { BookmarkIcon } from "lucide-react";
 import { useSearch } from "./useSearch";
 import { useUser } from "../login/useUser";
 import SocialLinks from "./SocialLinks";
-import myHomeLogo from "../images/logo/myHomeLogo.png";
+import Logo from "./Logo";
 import { useTheme } from "./useTheme";
 import { canSubmitSeriesUser, isAdminUser } from "../util/roleUtils";
 import { searchSeries, type RankedSeries } from "../api/manApi";
@@ -239,11 +239,8 @@ const Header = () => {
             className="flex items-center gap-3 rounded-full pr-1 transition hover:opacity-90"
             aria-label="Go to homepage"
           >
-            <img
-              src={myHomeLogo}
-              alt="Toon Ranks Logo"
-              className="h-11 w-11 object-contain"
-            />
+            <Logo />
+            <span className="sr-only">Toon Ranks</span>
           </a>
 
           <nav className="hidden items-center gap-2 sm:flex">

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,0 +1,23 @@
+/**
+ * Crisp, resolution-independent "TOON RANKS" wordmark. Replaces the old low-res
+ * PNG logo: rendered as styled text (Manrope, loaded site-wide), so it stays
+ * sharp at every size and adapts to light/dark themes automatically.
+ *
+ * Keeps the spirit of the original mark: stacked TOON / RANKS, playful tilt,
+ * blue identity — but with a modern gradient instead of a bitmap.
+ */
+export default function Logo({ className = "" }: { className?: string }) {
+  return (
+    <span
+      className={`inline-flex -rotate-2 select-none flex-col font-display font-extrabold uppercase leading-none ${className}`}
+      aria-hidden="true"
+    >
+      <span className="bg-gradient-to-r from-blue-600 via-blue-500 to-cyan-400 bg-clip-text text-[1.05rem] tracking-[0.08em] text-transparent dark:from-blue-400 dark:via-sky-400 dark:to-cyan-300">
+        Toon
+      </span>
+      <span className="text-[1.05rem] tracking-[0.02em] text-slate-900 dark:text-white">
+        Ranks
+      </span>
+    </span>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useLoaderData } from "react-router-dom";
+import { Link, useLoaderData } from "react-router-dom";
 import ManCard from "../components/ManCard";
 import AddSeriesModal from "../components/AddSeriesModal";
 import EditSeriesModal from "../components/EditSeriesModal";
@@ -338,6 +338,37 @@ const Home = () => {
     <>
 
       <div className="mx-auto w-full max-w-7xl px-3 pb-8 pt-4 sm:px-6 sm:pb-10 sm:pt-6 lg:px-8">
+        {/* Compact intro for first-time / logged-out visitors: says what the site
+            is and gives a clear next step. Hidden once signed in so regulars go
+            straight to the rankings. Also puts real above-the-fold copy (h1) in
+            the server HTML for SEO. */}
+        {!user && (
+          <section className="mb-4 rounded-[28px] border border-slate-200 bg-[radial-gradient(circle_at_top_right,_rgba(59,130,246,0.08),_transparent_40%),linear-gradient(135deg,_rgba(255,255,255,0.98),_rgba(248,250,252,0.95))] px-5 py-6 shadow-[0_24px_60px_-42px_rgba(15,23,42,0.45)] dark-theme-shell sm:px-8 sm:py-7">
+            <h1 className="max-w-2xl text-2xl font-bold tracking-tight text-slate-950 dark:text-white sm:text-3xl">
+              Rank, compare, and keep up with the series worth your time.
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 dark:text-slate-300 sm:text-[15px]">
+              Community-driven rankings for manga, manhwa, and manhua — rate
+              what you've read, track what you're reading, and find your next
+              series.
+            </p>
+            <div className="mt-4 flex flex-wrap items-center gap-2.5">
+              <Link
+                to="/signup"
+                className="rounded-full bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700"
+              >
+                Join free
+              </Link>
+              <Link
+                to="/how-rankings-work"
+                className="rounded-full border border-slate-200 bg-white/80 px-5 py-2.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50 dark-theme-chip dark:text-slate-200 dark:hover:bg-[#241d19]"
+              >
+                How rankings work
+              </Link>
+            </div>
+          </section>
+        )}
+
         <section className="overflow-hidden rounded-[28px] border border-slate-200 bg-white/90 shadow-[0_24px_60px_-42px_rgba(15,23,42,0.45)] dark-theme-shell">
           <RankingsToolbar
             contextLabel="Rankings"

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -121,7 +121,10 @@ export default function Root() {
           <SearchProvider>
             <div className="flex flex-col min-h-screen">
               <Header />
-              <main className="flex-grow bg-[linear-gradient(180deg,_#f8fafc_0%,_#ffffff_18%,_#ffffff_100%)] transition-colors dark:bg-[radial-gradient(circle_at_top_left,_rgba(45,212,191,0.08),_transparent_18%),radial-gradient(circle_at_top_right,_rgba(245,158,11,0.04),_transparent_18%),linear-gradient(180deg,_#18120f_0%,_#120f0d_18%,_#171210_100%)]">
+              {/* Light bg slightly deeper than the white cards (with a faint blue
+                  cast up top) so cards read as elevated surfaces instead of
+                  white-on-white. Dark bg unchanged. */}
+              <main className="flex-grow bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.05),_transparent_30%),linear-gradient(180deg,_#eef2f7_0%,_#f4f7fa_40%,_#f8fafc_100%)] transition-colors dark:bg-[radial-gradient(circle_at_top_left,_rgba(45,212,191,0.08),_transparent_18%),radial-gradient(circle_at_top_right,_rgba(245,158,11,0.04),_transparent_18%),linear-gradient(180deg,_#18120f_0%,_#120f0d_18%,_#171210_100%)]">
                 <Outlet />
                 <SessionExpiredModal
                   open={showExpired}


### PR DESCRIPTION
Design phase 2 (brand & identity): replaces the low-res PNG logo with a crisp, theme-aware vector wordmark (Manrope + gradient, sharp at all sizes); adds a compact homepage hero for logged-out visitors (tagline h1 + Join free / How rankings work CTAs — hidden when signed in, adds real above-the-fold copy to server HTML for SEO); deepens the light-mode page background so cards read as elevated surfaces. Checks: tsc/lint clean, unit 21/21, e2e 6/6, verified light+dark.