### PR TITLE
Android app promo

### DIFF
--- a/src/components/AndroidAppBanner.tsx
+++ b/src/components/AndroidAppBanner.tsx
@@ -1,0 +1,125 @@
+/**
+ * AndroidAppBanner
+ *
+ * A small, dismissible bottom banner shown only to Android browser visitors,
+ * inviting them to get the Toon Ranks Android app on Google Play.
+ *
+ * SSR safety: this app server-renders (ssr: true), so we never touch
+ * `navigator`/`localStorage` during render. We start hidden and only decide
+ * to reveal inside an effect on the client — same pattern as CookieBanner.
+ *
+ * Collision: CookieBanner is also a fixed bottom banner. To avoid stacking the
+ * two, we stay hidden until the cookie-consent choice has been made (the
+ * "cookie-consent" key with `decided: true`, written by CookieBanner). They
+ * therefore appear in sequence, never at once.
+ */
+
+import { useEffect, useState } from "react";
+import { PLAY_STORE_URL } from "../config/site";
+
+const DISMISS_KEY = "android-app-banner-dismissed";
+const COOKIE_CONSENT_KEY = "cookie-consent";
+
+function isAndroidBrowser(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /android/i.test(navigator.userAgent);
+}
+
+function cookieConsentDecided(): boolean {
+  try {
+    const raw = localStorage.getItem(COOKIE_CONSENT_KEY);
+    if (!raw) return false;
+    return JSON.parse(raw)?.decided === true;
+  } catch {
+    return false;
+  }
+}
+
+function alreadyDismissed(): boolean {
+  try {
+    return localStorage.getItem(DISMISS_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export default function AndroidAppBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!isAndroidBrowser() || alreadyDismissed()) return;
+
+    // Only show once the cookie banner has been dealt with, so the two
+    // bottom-fixed banners never overlap. Poll briefly for the decision.
+    if (cookieConsentDecided()) {
+      setVisible(true);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      if (cookieConsentDecided()) {
+        setVisible(true);
+        window.clearInterval(interval);
+      }
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  function dismiss() {
+    try {
+      localStorage.setItem(DISMISS_KEY, "true");
+    } catch {
+      // ignore storage failures — just hide for this session
+    }
+    setVisible(false);
+  }
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Get the Toon Ranks Android app"
+      className="fixed bottom-0 left-0 right-0 z-50 border-t border-slate-200 bg-white/95 px-4 py-3 shadow-[0_-8px_32px_-8px_rgba(15,23,42,0.12)] backdrop-blur-sm dark:border-[#322922]/80 dark:bg-[#18120f]/95"
+    >
+      <div className="mx-auto flex max-w-5xl items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <img
+            src="/android-chrome-192x192.png"
+            alt=""
+            aria-hidden="true"
+            className="h-9 w-9 shrink-0 rounded-lg"
+          />
+          <p className="min-w-0 text-sm leading-snug text-slate-700 dark:text-slate-200">
+            <span className="font-semibold text-slate-900 dark:text-white">
+              Toon Ranks
+            </span>{" "}
+            is available on Android.
+          </p>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <a
+            href={PLAY_STORE_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={dismiss}
+            className="rounded-full bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            Get app
+          </a>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label="Dismiss"
+            className="rounded-full border border-slate-300 px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-50 dark:border-[#3a3028] dark:text-slate-300 dark:hover:bg-[#241d19]"
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import SocialLinks from "./SocialLinks";
-import { OPERATOR_NAME, SITE_NAME } from "../config/site";
+import { OPERATOR_NAME, PLAY_STORE_URL, SITE_NAME } from "../config/site";
 
 const footerLinkClass =
   "rounded-full px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-[#241d19] dark:hover:text-white";
@@ -67,6 +67,24 @@ const Footer = () => {
               <li>
                 <a href="/privacy" className={footerLinkClass}>
                   Privacy
+                </a>
+              </li>
+              <li>
+                <a
+                  href={PLAY_STORE_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-full bg-slate-900 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-slate-700 dark:bg-white dark:text-slate-900 dark:hover:bg-slate-200"
+                >
+                  <svg
+                    aria-hidden="true"
+                    viewBox="0 0 512 512"
+                    className="h-3.5 w-3.5"
+                    fill="currentColor"
+                  >
+                    <path d="M325.3 234.3 104.6 13l280.8 161.2-60.1 60.1zM47 0C34 6.8 25.3 19.2 25.3 35.3v441.3c0 16.1 8.7 28.5 21.7 35.3l256.6-256L47 0zm425.2 225.6-58.9-34.1-65.7 64.5 65.7 64.5 60.1-34.1c18-14.3 18-46.5-1.2-60.8zM104.6 499l280.8-161.2-60.1-60.1L104.6 499z" />
+                  </svg>
+                  Get the Android app
                 </a>
               </li>
             </ul>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -2,6 +2,10 @@ export const SITE_ORIGIN = "https://www.toonranks.com";
 export const SITE_NAME = "Toon Ranks";
 export const OPERATOR_NAME = "Nofara LLC";
 
+// Android app on Google Play (package: com.toonranks.mobile).
+export const ANDROID_PACKAGE = "com.toonranks.mobile";
+export const PLAY_STORE_URL = `https://play.google.com/store/apps/details?id=${ANDROID_PACKAGE}`;
+
 export const SUPPORT_EMAIL = "support@toonranks.com";
 export const VERIFICATION_EMAIL = "noreply@toonranks.com";
 export const PASSWORD_RESET_EMAIL = "accounts@toonranks.com";

--- a/src/root.tsx
+++ b/src/root.tsx
@@ -14,6 +14,7 @@ import { SearchProvider } from "./components/SearchContext";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import CookieBanner from "./components/CookieBanner";
+import AndroidAppBanner from "./components/AndroidAppBanner";
 import { SessionExpiredModal } from "./components/SessionExpiredModal";
 import "./index.css";
 
@@ -133,6 +134,7 @@ export default function Root() {
               </main>
               <Footer />
               <CookieBanner />
+              <AndroidAppBanner />
             </div>
           </SearchProvider>
         </UserProvider>


### PR DESCRIPTION
Adds soft promotion of the Toon Ranks Android app to the website (phase 1):

- New PLAY_STORE_URL / ANDROID_PACKAGE constants in config/site.ts
- Footer "Get the Android app" link (opens Play Store in a new tab)
- AndroidAppBanner: a dismissible bottom banner shown only to Android
  browser visitors, gated behind the cookie-consent decision so it never
  overlaps CookieBanner. SSR-safe (decides visibility in useEffect, never
  during render); dismissal persists in localStorage.

Deliberately no homepage hero — keeps the site feeling like Toon Ranks,
not a download campaign. Profile/account-card placement deferred to phase 2.

Test: see UI steps in the PR. Verified footer link + no-banner-on-desktop
+ no hydration errors against the built SSR server.