### PR TITLE
Frontend public profile activity

### DIFF
--- a/src/api/manApi.ts
+++ b/src/api/manApi.ts
@@ -587,6 +587,10 @@ export interface AuthUser extends AvatarFields {
   username: string;
   email?: string | null;
   role?: UserRole | null;
+  // Public-profile visibility toggles (default true). Optional so older stored
+  // sessions without these fields still type-check.
+  public_ratings?: boolean;
+  public_posts?: boolean;
 }
 export interface AdminUser extends AuthUser {
   is_verified: boolean;
@@ -1982,6 +1986,22 @@ export interface ProfileReadingList {
   share_token: string;
 }
 
+export interface PublicSeriesRating {
+  series_id: number;
+  title: string | null;
+  cover_url: string | null;
+  type: SeriesType | null;
+  score: number;
+}
+
+export interface PublicForumPost {
+  post_id: number;
+  thread_id: number;
+  thread_title: string | null;
+  excerpt: string;
+  created_at: string;
+}
+
 export interface PublicProfile {
   username: string;
   role: string;
@@ -1993,12 +2013,27 @@ export interface PublicProfile {
   post_count: number;
   favourites: PublicFavourite[];
   reading_lists: ProfileReadingList[];
+  // null when the user has hidden that section (vs [] = public but empty).
+  ratings?: PublicSeriesRating[] | null;
+  posts?: PublicForumPost[] | null;
 }
 
 export const getPublicProfile = async (
   username: string
 ): Promise<PublicProfile> => {
   const res = await api.get<PublicProfile>(`/users/${username}`);
+  return res.data;
+};
+
+export interface PrivacySettings {
+  public_ratings: boolean;
+  public_posts: boolean;
+}
+
+export const updateMyPrivacy = async (
+  payload: Partial<PrivacySettings>
+): Promise<PrivacySettings> => {
+  const res = await api.patch<PrivacySettings>("/auth/me/privacy", payload);
   return res.data;
 };
 

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -6,6 +6,7 @@ import {
   getPublicProfile,
   resetMyAvatar,
   selectMyAvatarPreset,
+  updateMyPrivacy,
   uploadMyAvatar,
   updateMyUsername,
 } from "../api/manApi";
@@ -125,6 +126,28 @@ export default function AccountPage() {
   const [usernameInput, setUsernameInput] = useState("");
   const [usernameSaving, setUsernameSaving] = useState(false);
   const [usernameError, setUsernameError] = useState<string | null>(null);
+
+  // Public-profile visibility toggles
+  const [privacySaving, setPrivacySaving] = useState(false);
+
+  async function handlePrivacyToggle(
+    key: "public_ratings" | "public_posts",
+    value: boolean
+  ) {
+    if (!user) return;
+    const prev = user[key] ?? true;
+    // Optimistic: update the stored user immediately, revert if the API fails.
+    saveUser({ ...user, [key]: value }, setUser);
+    setPrivacySaving(true);
+    try {
+      await updateMyPrivacy({ [key]: value });
+    } catch {
+      saveUser({ ...user, [key]: prev }, setUser);
+      toast.error("Couldn't update your privacy setting. Please try again.");
+    } finally {
+      setPrivacySaving(false);
+    }
+  }
 
   // Keep draftRef in sync so the wheel handler can read it without a stale closure
   draftRef.current = draft;
@@ -569,6 +592,31 @@ export default function AccountPage() {
         </section>
       </div>
 
+      <section className="mt-8 rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm dark-theme-card">
+        <h2 className="text-2xl font-black text-slate-950 dark:text-white">
+          Privacy
+        </h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Choose what shows on your public profile.
+        </p>
+        <div className="mt-5 space-y-4">
+          <PrivacyToggleRow
+            label="Show my ratings"
+            description="Display the series you've rated on your public profile."
+            checked={user.public_ratings ?? true}
+            disabled={privacySaving}
+            onChange={(v) => handlePrivacyToggle("public_ratings", v)}
+          />
+          <PrivacyToggleRow
+            label="Show my forum posts"
+            description="Display your recent forum posts on your public profile."
+            checked={user.public_posts ?? true}
+            disabled={privacySaving}
+            onChange={(v) => handlePrivacyToggle("public_posts", v)}
+          />
+        </div>
+      </section>
+
       <FavouritesSection />
       <ForumActivitySection />
       <SeriesRatingsSection />
@@ -649,6 +697,53 @@ export default function AccountPage() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+function PrivacyToggleRow({
+  label,
+  description,
+  checked,
+  disabled = false,
+  onChange,
+}: {
+  label: string;
+  description: string;
+  checked: boolean;
+  disabled?: boolean;
+  onChange: (value: boolean) => void;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+          {label}
+        </p>
+        <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+          {description}
+        </p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={label}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={[
+          "relative mt-0.5 h-6 w-11 shrink-0 rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500",
+          disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
+          checked ? "bg-blue-600 dark:bg-blue-500" : "bg-slate-200 dark:bg-[#3a3028]",
+        ].join(" ")}
+      >
+        <span
+          className={[
+            "absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform",
+            checked ? "translate-x-5" : "translate-x-0",
+          ].join(" ")}
+        />
+      </button>
     </div>
   );
 }

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -305,6 +305,105 @@ export default function UserProfilePage() {
         </div>
       </div>
 
+      {/* ── Ratings (only when the user keeps them public) ────────────────── */}
+      {profile.ratings != null && (
+        <div className="mb-6 rounded-[2rem] border border-slate-200/80 bg-white px-6 py-8 shadow-[0_18px_50px_rgba(15,23,42,0.06)] dark:border-[#342b24] dark:bg-[linear-gradient(145deg,rgba(27,22,18,0.98),rgba(20,16,13,0.97))] dark:shadow-[0_18px_50px_rgba(0,0,0,0.5)] sm:px-10 sm:py-10">
+          <div className="mb-6">
+            <h2 className="text-xl font-black text-slate-950 dark:text-white sm:text-2xl">
+              Ratings
+            </h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              {profile.ratings.length > 0
+                ? `Series ${profile.username} has rated.`
+                : `${profile.username} hasn't rated any series yet.`}
+            </p>
+          </div>
+
+          {profile.ratings.length > 0 && (
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+              {profile.ratings.map((rating) => (
+                <Link
+                  key={rating.series_id}
+                  to={`/series/${rating.series_id}`}
+                  className="group relative aspect-[2/3]"
+                  title={rating.title ?? undefined}
+                >
+                  <div className="h-full w-full overflow-hidden rounded-[18px] border border-slate-200 bg-slate-100 shadow-sm dark:border-[#2e2520] dark:bg-[#1e1712]">
+                    {rating.cover_url ? (
+                      <img
+                        src={rating.cover_url}
+                        alt={rating.title ?? "Series cover"}
+                        className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center p-1">
+                        <span className="text-center text-[10px] leading-tight text-slate-400 dark:text-slate-600">
+                          {rating.title}
+                        </span>
+                      </div>
+                    )}
+                    {/* Score badge — dark scrim so it stays legible over any cover */}
+                    <div className="absolute right-2 top-2 inline-flex items-center gap-1 rounded-full bg-slate-900/85 px-2 py-0.5 text-xs font-bold text-white ring-1 ring-white/10 backdrop-blur-sm">
+                      <span className="text-amber-300">★</span>
+                      {rating.score.toFixed(1)}
+                    </div>
+                    {/* Hover title overlay */}
+                    <div className="absolute inset-0 flex flex-col justify-end rounded-[18px] bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+                      <div className="p-2.5 pb-3">
+                        <p className="line-clamp-2 text-xs font-semibold leading-tight text-white drop-shadow">
+                          {rating.title}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ── Forum Activity (only when the user keeps posts public) ─────────── */}
+      {profile.posts != null && (
+        <div className="mb-6 rounded-[2rem] border border-slate-200/80 bg-white px-6 py-8 shadow-[0_18px_50px_rgba(15,23,42,0.06)] dark:border-[#342b24] dark:bg-[linear-gradient(145deg,rgba(27,22,18,0.98),rgba(20,16,13,0.97))] dark:shadow-[0_18px_50px_rgba(0,0,0,0.5)] sm:px-10 sm:py-10">
+          <div className="mb-6">
+            <h2 className="text-xl font-black text-slate-950 dark:text-white sm:text-2xl">
+              Forum Activity
+            </h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              {profile.posts.length > 0
+                ? `Recent posts from ${profile.username}.`
+                : `${profile.username} hasn't posted in the forum yet.`}
+            </p>
+          </div>
+
+          {profile.posts.length > 0 && (
+            <div className="grid gap-3">
+              {profile.posts.map((post) => (
+                <Link
+                  key={post.post_id}
+                  to={`/forum/${post.thread_id}`}
+                  className="group rounded-2xl border border-slate-100 bg-slate-50/60 px-5 py-4 transition hover:border-slate-300 hover:bg-slate-100/80 dark:border-[#2e2520] dark:bg-[#1a1410] dark:hover:border-[#3a3028] dark:hover:bg-[#201a16]"
+                >
+                  <p className="truncate text-sm font-semibold text-slate-900 dark:text-stone-100">
+                    {post.thread_title ?? "Thread"}
+                  </p>
+                  <p className="mt-1 line-clamp-2 text-sm text-slate-500 dark:text-slate-400">
+                    {post.excerpt}
+                  </p>
+                  {post.created_at && (
+                    <p className="mt-1 text-xs text-slate-400 dark:text-slate-500">
+                      {formatJoinDate(post.created_at)}
+                    </p>
+                  )}
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* ── Public Reading Lists (only if any are public) ─────────────────── */}
       {hasLists && (
         <div className="mb-6 rounded-[2rem] border border-slate-200/80 bg-white px-6 py-8 shadow-[0_18px_50px_rgba(15,23,42,0.06)] dark:border-[#342b24] dark:bg-[linear-gradient(145deg,rgba(27,22,18,0.98),rgba(20,16,13,0.97))] dark:shadow-[0_18px_50px_rgba(0,0,0,0.5)] sm:px-10 sm:py-10">

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -45,6 +45,10 @@ export interface User extends AvatarFields {
   username: string;
   email?: string | null;
   role?: UserRole | null; // allow null
+  // Public-profile visibility toggles (default true). Optional so older stored
+  // sessions without these fields still type-check.
+  public_ratings?: boolean;
+  public_posts?: boolean;
 }
 
 export interface UserContextType {


### PR DESCRIPTION
## Summary
- Web public profile now renders the user's rated series (with score) and
  recent forum posts, gated on the backend public_ratings/public_posts flags
  (section hidden when the API returns null).
- Account page gains a Privacy card with two toggles (PATCH /auth/me/privacy),
  optimistic with revert-on-error.
- Types + API wrapper updated; mirrors the mobile feature.

## Test plan
- [ ] Profile shows Ratings + Forum Activity; hidden sections respect the flags
- [ ] Account Privacy toggles persist and update the profile on next visit
- [ ] Rating → series, post → thread; dark mode + mobile OK