### PR TITLE
Frontend card action align

### DIFF
--- a/src/components/ManCard.tsx
+++ b/src/components/ManCard.tsx
@@ -182,7 +182,7 @@ const ManCard = ({
             ) : null}
           </div>
 
-          <div className="mt-3 flex flex-1 flex-col space-y-2 px-2 pb-2 sm:mt-4 sm:px-2.5">
+          <div className="mt-3 flex flex-1 flex-col gap-2 px-2 pb-2 sm:mt-4 sm:px-2.5">
             <h2 className="line-clamp-2 min-h-[2.6rem] w-full text-[15px] font-semibold leading-5 text-slate-900 dark:text-white sm:text-base sm:leading-normal" title={title}>
               {title}
             </h2>
@@ -231,7 +231,7 @@ const ManCard = ({
               </p>
             )}
 
-            <div className="mt-3 flex flex-wrap items-center gap-y-2 text-sm text-gray-700 dark:text-slate-300">
+            <div className="mt-auto flex flex-wrap items-center gap-y-2 pt-1 text-sm text-gray-700 dark:text-slate-300">
               {showVotes ? (
                 <div className="flex items-center space-x-1">
                   <UserIcon className="h-3.5 w-3.5 text-blue-400" />


### PR DESCRIPTION
## Summary
- Fix Home card (ManCard) alignment: when a title's author and artist are the
  same person, the artist line is omitted, which pushed the List/Compare row
  up out of line with neighbouring cards.
- Switched the credits container from space-y-2 to gap-2 and changed the
  action row from mt-3 to mt-auto, pinning it to the bottom so all cards'
  actions align regardless of credit-line count.

## Test plan
- [ ] Same-author card's List/Compare row aligns with different-author cards
- [ ] Holds across mobile/desktop widths and dark mode