### PR TITLE
updating uat

### DIFF
--- a/.claude/skills/write-article/SKILL.md
+++ b/.claude/skills/write-article/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: write-article
+description: >-
+  Write and publish a high-quality, original article for the Toon Ranks
+  /articles section (manga, manhwa, manhua). Use when asked to draft, add, or
+  publish a Toon Ranks article / blog post / editorial piece.
+---
+
+# Skill: write-article (pointer)
+
+The canonical, comprehensive version of this skill lives in the repo's
+discoverable skills folder so **any** AI can find and follow it:
+
+> **`skills/write-article/SKILL.md`**
+
+Open that file and follow it exactly. It references its companion files
+(`AUTHORING_GUIDE.md`, `PROMPT_TEMPLATES.md`, `TOPICS.md`) and the
+`skills/generate-article-image` skill.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,19 @@ See `docs/CONVENTIONS.md` for the full reference. Short version:
 
 ---
 
+## Repo skills
+
+Reusable, AI-agnostic task playbooks live in **`skills/`** (see
+`skills/README.md`). To "use the **X** skill," open `skills/X/SKILL.md` and
+follow it. Notably:
+
+- **write-article** — author & publish a `/articles` post to the house standard
+  (`skills/write-article/`).
+- **generate-article-image** — make/source an original, royalty-free, on-brand
+  article image (`skills/generate-article-image/`).
+
+---
+
 ## Related repos
 
 | Repo | Purpose | Deployment |

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-5886971570640795, DIRECT, f08c47fec0942fa0

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
 Sitemap: https://api.toonranks.com/sitemap.xml
+Sitemap: https://www.toonranks.com/sitemap-articles.xml

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,26 @@
+# Skills
+
+Repo skills are **self-contained task playbooks** any AI (or a human) can find
+and follow. They don't depend on a specific tool's private skill mechanism —
+they're just discoverable Markdown.
+
+## How to use a skill
+
+When asked to "use the **X** skill," open **`skills/X/SKILL.md`** and follow it
+exactly. A skill may reference companion files in its own folder and may
+reference other skills by path — follow those too as needed.
+
+## Available skills
+
+| Skill | What it does | Entry point |
+|---|---|---|
+| **write-article** | Write & publish a high-quality, original article for the Toon Ranks `/articles` section (manga/manhwa/manhua). Enforces the house style, adds it to the code, verifies the build. | [`skills/write-article/SKILL.md`](./write-article/SKILL.md) |
+| **generate-article-image** | Create (or source) an original, royalty-free, on-brand hero/inline image for an article, license-clear for commercial use. Used by `write-article` or standalone. | [`skills/generate-article-image/SKILL.md`](./generate-article-image/SKILL.md) |
+
+## Convention
+
+- Each skill is a folder under `skills/` with a **`SKILL.md`** entry point.
+- A skill may include companion docs in its folder (guides, templates, logs).
+- A skill is **comprehensive**: an AI that finds it should be able to complete
+  the task from the SKILL.md plus the files it references — no outside context
+  required beyond the repo.

--- a/skills/generate-article-image/SKILL.md
+++ b/skills/generate-article-image/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: generate-article-image
+description: >-
+  Create (or source) an original, royalty-free, on-brand hero or inline image
+  for a Toon Ranks article — license-clear for commercial use, never copyrighted
+  manga art. Used by the write-article skill or standalone. Produces an
+  optimized file under public/articles/<slug>/ and the image metadata to wire
+  into src/content/articles.ts.
+---
+
+# Skill: generate-article-image
+
+Produce **one original, royalty-free, on-brand hero image (16:9)** for a Toon
+Ranks article — and optional inline images. If you can generate images, make
+one. If you can't, give license-clear sourcing guidance and leave the image
+unset. The result is wired into the article's `image` field.
+
+## Hard rules (read first)
+
+- **Original / royalty-free / owned only**, and **license-clear for commercial
+  use**. Never depict copyrighted characters, real IP/franchises, brand logos,
+  watermarks, or recognizable real people. **No manga/manhwa panels or official
+  covers.**
+- Don't prompt for a specific living artist's style by name or a named
+  franchise — keep it generic and original.
+- **No text baked into the image** (or only minimal/generic) — the page renders
+  the title separately.
+
+## Brand & style (Toon Ranks)
+
+- Subject: manga/manhwa/manhua **discovery & community**. Modern, clean, friendly.
+- Must read well in **both light and dark mode**, and sit nicely behind/around
+  text — keep the center relatively calm with generous negative space.
+- Palette: the site's accents — **indigo/blue and teal, with warm amber
+  highlights**; deep near-black backgrounds work for dark mode.
+- License-safe aesthetics to choose from: abstract/gradient compositions;
+  clean **flat-vector** illustration with generic figures/objects (not real
+  characters); flat-design motifs (books, comic panels, speech bubbles, stars/
+  rankings, a phone with a vertical-scroll strip); subtle texture.
+- **Match the article concept**, e.g.: "what is a webtoon" → stylized phone +
+  abstract vertical-scroll strip; "how scoring works" → abstract bars/stars;
+  "beginner guide" → an open path/doorway motif.
+
+## Building the prompt (for an image generator)
+
+Compose: `[concept tied to the article]` + `[composition: 16:9 banner, calm
+center for text, generous negative space]` + `[style: e.g. "modern flat-vector
+illustration" or "clean abstract gradient"]` + `[palette: indigo/teal with amber
+accents, dark-friendly]` + `[constraints: "no text, no logos, no watermark, no
+copyrighted characters, original artwork"]`.
+
+Example — "What is a webtoon?":
+> Modern flat-vector illustration of a stylized smartphone showing an abstract
+> vertical-scroll comic strip; clean geometric shapes; indigo and teal with
+> amber accents; dark background; 16:9 banner; generous negative space; no text,
+> no logos, no recognizable characters; original artwork.
+
+## Output specs
+
+- **16:9**, ~1200px wide.
+- Export optimized **`.webp`** (or `.jpg`), target **under ~150 KB**.
+- Save the hero to **`public/articles/<slug>/hero.webp`** (create the folder).
+  Inline images go in the same folder with descriptive filenames.
+- Write **descriptive alt text** (what's shown) — not keyword stuffing.
+
+## Wire it into the article
+
+In `src/content/articles.ts`, set:
+```ts
+image: { src: "/articles/<slug>/hero.webp", alt: "<concise description>" }
+```
+For inline images, use Markdown in the body:
+`![concise description](/articles/<slug>/<file>.webp)`
+
+## If you cannot generate images
+
+Provide:
+1. **3 stock-search queries** for Unsplash / Pexels / Pixabay that fit the
+   concept and the brand palette.
+2. The **licensing rule**: only images free for commercial use; verify each
+   image's license; if a source requires attribution, add it at the bottom of
+   the article body.
+3. Leave the article's `image` **unset** until a real file is added — never use
+   a copyrighted image as a placeholder.

--- a/skills/write-article/AUTHORING_GUIDE.md
+++ b/skills/write-article/AUTHORING_GUIDE.md
@@ -1,0 +1,264 @@
+# Toon Ranks — Article Authoring Guide
+
+This is the standard every Toon Ranks article must meet. It exists so that
+articles written with **any** generative AI come out consistent, original, and
+genuinely good — never thin, repetitive, or obviously machine-made. Read it in
+full before writing. The publish checklist at the end is mandatory.
+
+---
+
+## 1. What Toon Ranks is (context for every article)
+
+Toon Ranks is a **community ranking and review platform for manga, manhwa, and
+manhua**. Members rate series across categories (story, art, characters,
+world-building, drama/action); scores are the average of those category
+averages. There's a forum, public profiles, reading lists, a Rankers
+leaderboard, and a Compare tool. The site does **not** host the comics — it
+helps people discover, rank, and discuss them.
+
+Articles exist to (a) give readers real value, (b) bring in search traffic on
+manga/manhwa/manhua topics, and (c) make the site content-rich (which also
+supports AdSense). Every article should feel like it belongs to a site run by
+people who actually read this stuff.
+
+---
+
+## 2. Audience & voice
+
+**Audience:** manga/manhwa/manhua readers — from curious newcomers to people
+deep in the hobby. Assume intelligence; don't over-explain basics unless the
+article is explicitly a beginner guide.
+
+**Voice:** a knowledgeable, opinionated friend who reads widely and is happy to
+recommend (and gently warn). Specifically:
+
+- **Confident and concrete**, not hedgy. Take positions. "Regression stories
+  live or die on their payoff" beats "Some people may feel that payoff can
+  sometimes matter."
+- **Plain and warm**, not corporate or hype-y. No marketing voice.
+- **Specific.** Name real genres, formats, and tropes. Use concrete examples.
+  (When naming actual series, only state things you're confident are true —
+  see §7 on facts.)
+- **Economical.** Every sentence earns its place. If a paragraph could be
+  deleted without loss, delete it.
+
+---
+
+## 3. The non-negotiable quality bar (anti-AI-slop)
+
+Most "AI articles" fail the same way: generic, padded, hedged, and
+structurally identical. Avoid every one of these:
+
+**Banned / avoid phrases and patterns:**
+- "In today's fast-paced world", "In the world of…", "When it comes to…"
+- "Whether you're a seasoned reader or just starting out…"
+- "Let's dive in", "Let's explore", "Without further ado", "In conclusion",
+  "In summary", "At the end of the day"
+- Stacked transitions: "Moreover," "Furthermore," "Additionally," opening
+  consecutive paragraphs.
+- "It's not just X, it's Y" as a crutch (occasional use is fine; pattern abuse is not).
+- Empty hedging: "arguably," "it could be said that," "many would agree."
+- Rhetorical-question filler: "But what does that really mean? Let's find out."
+- Restating the title/prompt back as the first sentence.
+- Listicles where every item is one vague sentence with no real insight.
+- Uniform paragraph lengths and identical sentence rhythm.
+
+**Do instead:**
+- Open with a real hook — an observation, a tension, a concrete scenario — then
+  get to the point within two sentences.
+- **Vary rhythm.** Mix short punchy sentences with longer ones. Vary paragraph
+  length (1–4 sentences).
+- Earn every claim with a specific reason or example.
+- Have a point of view. A good article could only have been written by someone
+  who actually thinks about this stuff.
+- Cut throat-clearing. Cut summaries that just repeat the body.
+
+**The litmus test:** would a knowledgeable reader find at least one genuinely
+useful or interesting idea they didn't already have? If not, the article isn't
+ready.
+
+---
+
+## 4. Originality & non-repetition
+
+- **Never** copy or lightly paraphrase another site, wiki, or another Toon
+  Ranks article. Original wording and original framing, always.
+- Before writing, **check `TOPICS.md`.** Do not repeat a topic *or a close
+  angle* already published. "Best manhwa for beginners" and "Where to start
+  with manhwa" are the same article — don't write the second one.
+- **Vary the format** across the catalog so it doesn't read like a template
+  farm: explainers, beginner guides, opinion/analysis, curated lists,
+  format/industry deep-dives, "how the site works" pieces.
+- After publishing, **add the topic to `TOPICS.md`** so the next writer (human
+  or AI) won't collide with it.
+
+---
+
+## 5. Structure & length
+
+**Length:** ~700–1,200 words. Long enough to be substantial; never padded to
+hit a number. A tight 750-word piece beats a bloated 1,400-word one.
+
+**Shape:**
+1. **Title** — specific and honest. Promises something concrete. Not clickbait,
+   not vague. (e.g., "Manga vs Manhwa vs Manhua: What's Actually Different?")
+2. **Intro (1–2 short paragraphs)** — hook + a clear sense of what the reader
+   gets. No throat-clearing.
+3. **Body** — `##` H2 sections (use `###` H3 only when a section needs
+   sub-parts). Each section delivers one idea. Use lists where they genuinely
+   help (steps, comparisons, options) — not to dodge writing prose.
+4. **Close** — a short, earned ending that leaves the reader with a takeaway or
+   a next step. **Never** label it "Conclusion" and never just restate the body.
+5. **Internal links** — weave in at least **two** relevant links (see §8).
+
+**Formatting (Markdown):**
+- Do **not** include an `# H1`. The page renders the title separately.
+- Section headings: `## Heading`. Sub-headings: `### Subheading`.
+- **Bold** for genuinely key terms only — not decoration.
+- Links: `[anchor text](/path)` — descriptive anchor text, never "click here".
+- Keep paragraphs to 2–4 sentences. Blank line between blocks.
+- Lists: `-` for bullets, `1.` for ordered. Keep items substantive.
+
+---
+
+## 6. SEO & AdSense requirements
+
+- **One clear search intent per article.** Write the piece a person searching
+  that phrase actually wants.
+- **Title:** front-load the meaningful words; keep it under ~60 characters where
+  practical.
+- **Description (the `description` field):** 1–2 sentences, ~120–160 characters,
+  compelling and accurate. This is the meta description and the index-card blurb.
+- **Substantial original text** in complete sentences/paragraphs — this is the
+  single biggest factor for AdSense approval (thin/image-only pages get
+  rejected).
+- **No prohibited content** (per AdSense policies): no adult/explicit content,
+  no copyrighted text or images, no hateful/violent content, no
+  scraped/auto-generated filler.
+- Internal links (§8) give crawlers paths and help SEO.
+
+---
+
+## 7. Facts & safety
+
+- **Do not fabricate.** Never invent plot details, release dates, sales figures,
+  author credits, or quotes. If you're not sure a specific claim about a real
+  series is true, **stay general** ("many long-running shōnen series…") instead
+  of stating a specific falsehood.
+- Prefer **evergreen, conceptual** content (how formats differ, how to choose,
+  how scoring works) over time-sensitive claims that rot.
+- If an article references a specific series, keep claims to widely-known,
+  safe-to-state facts (its format/country, broad genre). When in doubt, cut it.
+- No medical, legal, or financial advice. Stay in the lane: comics discovery.
+
+---
+
+## 8. Internal linking (required)
+
+Every article links to **at least two** relevant internal destinations, with
+descriptive anchor text:
+
+- Home / rankings: `/`
+- A series page: `/series/:id` (only if you're confident of the ID; otherwise
+  link to rankings)
+- How scoring works: `/how-rankings-work`
+- Compare tool: `/compare`
+- Type-filtered rankings: `/type/MANGA`, `/type/MANHWA`, `/type/MANHUA`
+- Another relevant article: `/articles/<slug>`
+
+Links should feel natural in the sentence, not bolted on at the end.
+
+---
+
+## 9. Images (optional, encouraged)
+
+Images aren't required for AdSense, but they improve the page. Rules:
+
+- **Only royalty-free or owned images.** Acceptable: your own graphics,
+  AI-generated images you create, or properly-licensed stock (Unsplash, Pexels,
+  Pixabay, or similar — check each image's license). **Never** use copyrighted
+  manga/manhwa panels, official covers, or fan art. This is both a copyright and
+  an AdSense risk.
+- **On-theme and relevant** to the article (and to the site's aesthetic).
+- **Optimize:** ~1200px wide max, compressed, `.webp` or `.jpg`, ideally
+  under ~150 KB.
+- **Place** files in `public/articles/<slug>/` and reference them with a root
+  path, e.g. `/articles/<slug>/hero.webp`.
+- **Alt text is mandatory** and must describe the image, not stuff keywords.
+- If a source requires attribution, add it at the bottom of the article body.
+
+The hero image goes in the article's `image` field (see §10). You may also place
+images inline in the body with Markdown: `![descriptive alt](/articles/<slug>/inline.webp)`.
+
+---
+
+## 10. The data shape & how to add an article
+
+Articles live in `src/content/articles.ts` in the exported `articles` array.
+The TypeScript type:
+
+```ts
+interface Article {
+  slug: string;            // kebab-case, unique, stable, URL-safe (e.g. "where-to-start-with-manhwa")
+  title: string;
+  description: string;     // ~120–160 chars; meta description + card blurb
+  author: string;          // usually "The Toon Ranks Team"
+  publishedAt: string;     // ISO date "YYYY-MM-DD"
+  updatedAt: string;       // ISO date "YYYY-MM-DD" (same as published on first publish)
+  tags: string[];          // 2–4 tags; reuse existing ones where possible (see TOPICS.md)
+  image?: { src: string; alt: string };  // optional hero; royalty-free/owned only
+  body: string;            // the article, in Markdown (no H1)
+}
+```
+
+**Rules for fields:**
+- `slug` — lowercase kebab-case, unique across all articles, never change it
+  after publishing (it's the URL; changing it breaks links/SEO).
+- `publishedAt` / `updatedAt` — `YYYY-MM-DD`. Newest `publishedAt` sorts to the
+  top of the index automatically.
+- `tags` — keep a small, consistent vocabulary (e.g. `Guides`, `Beginners`,
+  `Manga`, `Manhwa`, `Manhua`, `Rankings`, `Recommendations`, `Community`).
+- `body` — Markdown string. Mind escaping: the file uses template literals
+  (backticks), so a literal backtick in the body must be escaped.
+
+**To add one:** append a new object to the `articles` array. The index page,
+the `/articles/:slug` route, SEO meta, and JSON-LD all pick it up automatically.
+Helpers `getAllArticles()` (newest first), `getArticleBySlug()`, and
+`readingTimeMinutes()` already exist.
+
+---
+
+## 11. Workflow (every article)
+
+1. **Pick a topic** from `TOPICS.md` (or add a new, non-overlapping one). Confirm
+   it doesn't duplicate an existing article's angle.
+2. **Draft** using the article prompt in `PROMPT_TEMPLATES.md`, with this guide
+   as the standard.
+3. **Edit hard** for voice and the §3 quality bar. Read it aloud in your head —
+   cut anything that sounds generic or padded. Run the "de-slop" refine prompt
+   if it feels machine-made.
+4. **Fact pass** (§7): remove or generalize anything you can't stand behind.
+5. **Image** (optional): source a royalty-free/owned image, optimize, put it in
+   `public/articles/<slug>/`, write real alt text.
+6. **Add to `src/content/articles.ts`** with the correct fields.
+7. **Log it in `TOPICS.md`** (move from backlog to published; note the angle).
+8. **Build & preview:** `npm run build`, then run the dev/preview server and open
+   `/articles/<slug>` — check it renders, links work, and the image loads.
+9. **Run the publish checklist below.**
+
+---
+
+## 12. Publish checklist (all must be ✅)
+
+- [ ] Original wording and an original angle (not in `TOPICS.md` already)
+- [ ] Passes the §3 quality bar — no banned phrases, varied rhythm, real point of view
+- [ ] Genuinely useful: a knowledgeable reader learns/feels something
+- [ ] ~700–1,200 words, scannable (H2/H3, short paragraphs)
+- [ ] No fabricated facts; specific claims about real series are safe to state
+- [ ] ≥2 natural internal links with descriptive anchor text
+- [ ] `title` specific & honest; `description` 120–160 chars & compelling
+- [ ] `slug` unique, kebab-case, stable; dates in `YYYY-MM-DD`; sensible tags
+- [ ] Body is valid Markdown, **no H1**, backticks escaped if any
+- [ ] Image (if any) is royalty-free/owned, optimized, in `public/articles/<slug>/`, with real alt text
+- [ ] Added to `src/content/articles.ts`; logged in `TOPICS.md`
+- [ ] `npm run build` passes; previewed `/articles/<slug>` and it renders correctly

--- a/skills/write-article/PROMPT_TEMPLATES.md
+++ b/skills/write-article/PROMPT_TEMPLATES.md
@@ -1,0 +1,97 @@
+# Prompt Templates
+
+Copy-paste prompts for drafting and refining Toon Ranks articles with any
+generative AI. **Always** paste `AUTHORING_GUIDE.md` into the same conversation
+first (or attach it), then use these. Fill in every `<…>` placeholder.
+
+---
+
+## 1. Article draft prompt
+
+> You are writing an article for **Toon Ranks**, a community ranking and review
+> platform for manga, manhwa, and manhua. Follow the attached `AUTHORING_GUIDE.md`
+> exactly — especially the voice (§2), the anti-AI-slop quality bar (§3), and the
+> structure (§5). Do not violate any banned-phrase or formatting rule.
+>
+> **Topic:** `<topic>`
+> **Angle / unique take:** `<the specific point of view or hook — must not repeat existing articles>`
+> **Format:** `<explainer | beginner guide | opinion/analysis | curated list | format/industry deep-dive | how-the-site-works>`
+> **Target reader:** `<newcomer | regular reader | both>`
+> **Must mention:** `<concepts/sections to include, if any>`
+> **Must avoid:** `<anything off-limits — and never fabricate facts about real series>`
+> **Target length:** `<700–1200>` words
+> **Internal links to weave in (≥2):** `<e.g. /how-rankings-work, /compare, /type/MANHWA, /articles/<slug>>`
+>
+> Output:
+> 1. `title` (specific, honest, < ~60 chars)
+> 2. `description` (120–160 chars, compelling, accurate)
+> 3. `tags` (2–4, from: Guides, Beginners, Manga, Manhwa, Manhua, Rankings, Recommendations, Community — or propose one)
+> 4. `body` in Markdown — **no H1**, use `##`/`###`, short paragraphs, varied rhythm, ≥2 internal links woven in naturally.
+>
+> Have a real point of view. Be specific and concrete. Cut every sentence that
+> doesn't earn its place. Do not state any specific fact about a real series
+> unless it is widely known and safe; otherwise stay general.
+
+---
+
+## 2. De-slop / humanize refine prompt
+
+Use when a draft feels generic or machine-made.
+
+> Revise the article below so it reads like strong human writing, per
+> `AUTHORING_GUIDE.md` §3. Specifically:
+> - Remove every banned phrase and filler transition.
+> - Vary sentence and paragraph length; break uniform rhythm.
+> - Replace vague claims with specific, concrete ones (or cut them).
+> - Strengthen the point of view; make sure each section delivers a real idea.
+> - Cut throat-clearing intros and any summary that just restates the body.
+> Keep the meaning and the internal links. Return the full revised Markdown body.
+>
+> `<paste draft>`
+
+---
+
+## 3. Title + description prompt
+
+> Given this article body, write: (a) 3 candidate `title`s — specific, honest,
+> under ~60 chars, no clickbait; and (b) a `description` of 120–160 characters
+> that's compelling and accurate (used as the meta description and card blurb).
+> `<paste body>`
+
+---
+
+## 4. Image brief prompt
+
+For an AI image generator, or to derive a stock-search query.
+
+> Suggest a hero image concept for an article titled "`<title>`" on a
+> manga/manhwa/manhua discovery site. It must be **original/royalty-free-style**
+> — no manga panels, no copyrighted characters, no recognizable IP. On-theme,
+> clean, works behind text, fits a 16:9 banner. Give: (a) an AI image-gen prompt,
+> and (b) 3 stock-photo search queries (Unsplash/Pexels) as a fallback. Also
+> provide concise, descriptive **alt text** (no keyword stuffing).
+
+(Reminder: optimize to ~1200px / `.webp` or `.jpg` / under ~150 KB, place in
+`public/articles/<slug>/`, and only use images you own or are licensed/royalty-free.)
+
+---
+
+## 5. Fact-safety review prompt
+
+> Review the article below for any specific factual claim about a real manga,
+> manhwa, or manhua series, creator, date, or number. For each, flag it and say
+> whether it's widely known and safe to state. Recommend cutting or generalizing
+> anything uncertain. Do not add new claims.
+> `<paste body>`
+
+---
+
+## 6. Final formatting prompt (optional)
+
+> Convert/verify this article as a JavaScript-safe Markdown string for
+> `src/content/articles.ts`: ensure there is **no H1**, headings use `##`/`###`,
+> links use `/path` form, and any literal backticks are escaped. Then give me the
+> complete article object (`slug`, `title`, `description`, `author`,
+> `publishedAt`, `updatedAt`, `tags`, optional `image`, `body`) ready to paste
+> into the `articles` array. Use today's date (`YYYY-MM-DD`) for the dates and a
+> unique kebab-case `slug`.

--- a/skills/write-article/SKILL.md
+++ b/skills/write-article/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: write-article
+description: >-
+  Write and publish a high-quality, original article for the Toon Ranks
+  /articles section (manga, manhwa, manhua). Use when asked to draft, add, or
+  publish a Toon Ranks article / blog post / editorial piece. Enforces the
+  house style in AUTHORING_GUIDE.md, generates or sources an image via the
+  generate-article-image skill, adds the article to src/content/articles.ts,
+  logs it in TOPICS.md, and verifies the build.
+---
+
+# Skill: write-article
+
+You are authoring an article for the Toon Ranks `/articles` section. This skill
+is comprehensive — everything you need is in this folder plus the files it
+points to. Follow it end to end.
+
+## Companion files (read these)
+
+- **`AUTHORING_GUIDE.md`** (same folder) — the authoritative standard: voice,
+  the anti-AI-slop quality bar, originality rules, structure, SEO/AdSense
+  requirements, facts/safety, internal linking, the `Article` data shape, and
+  the publish checklist. **Read it in full before writing.**
+- **`PROMPT_TEMPLATES.md`** (same folder) — draft, de-slop/humanize, title,
+  image-brief, and fact-safety prompts.
+- **`TOPICS.md`** (same folder) — published log + backlog. Check it to avoid
+  repeating a topic or angle; update it after publishing.
+- **`skills/generate-article-image/SKILL.md`** — how to create or source an
+  original, royalty-free, on-brand image. Use it for the image step.
+
+## Procedure
+
+1. **Read `AUTHORING_GUIDE.md`** and hold yourself to it. The quality bar (§3),
+   originality (§4), facts/safety (§7), and the checklist (§12) are not optional.
+2. **Pick / confirm the topic** against `TOPICS.md`. Do not repeat a published
+   topic or a close angle. If the user gave one, confirm no overlap; otherwise
+   propose distinct backlog options and let them choose. Vary the format across
+   the catalog.
+3. **Draft** to the standard — real point of view, specific and concrete,
+   banned phrases avoided, varied rhythm. Body is Markdown, **no H1**, `##`/`###`
+   headings, short paragraphs, and ≥2 natural internal links (`/`,
+   `/series/:id`, `/how-rankings-work`, `/compare`, `/type/MANGA|MANHWA|MANHUA`,
+   other `/articles/<slug>`).
+4. **Self-review** against §3 (cut anything generic/padded; run the de-slop
+   prompt if needed) and §7 (remove or generalize any unverified claim about a
+   real series — never fabricate).
+5. **Image** — follow `skills/generate-article-image/SKILL.md`. If you can
+   generate images, produce an original, royalty-free, on-brand 16:9 hero,
+   optimize it, save it to `public/articles/<slug>/hero.webp`, and set the
+   article's `image` field. If you cannot, leave `image` unset and note the
+   stock-search guidance from that skill. **Never** use copyrighted manga art.
+6. **Add to code** — append a complete object to the `articles` array in
+   `src/content/articles.ts` per the §10 shape (unique kebab-case `slug`,
+   `YYYY-MM-DD` dates, sensible tags). Escape literal backticks in the body.
+7. **Log it** — move the topic to the "Published" table in `TOPICS.md` with the
+   slug and a one-line angle note.
+8. **Verify** — run `npm run build` and confirm it passes. If a preview/dev
+   server is available, open `/articles/<slug>` and check it renders, links
+   work, and any image loads.
+9. **Run the publish checklist** (`AUTHORING_GUIDE.md` §12). Every item must
+   pass.
+
+## Non-negotiables
+
+- Original wording and an original angle. Never copy; never reuse a published angle.
+- Never invent facts about real series, creators, dates, or numbers.
+- Images: original / royalty-free / owned only. Never copyrighted manga art.
+- Respect the repo workflow: don't commit/push unless told; end with
+  preview/test steps + a one-line commit message + a short PR description.
+
+## Handoff
+
+Summarize: new slug + title, files changed (`src/content/articles.ts`,
+`skills/write-article/TOPICS.md`, any image under `public/articles/<slug>/`),
+build result, preview steps, a one-line commit message, and a short PR
+description.

--- a/skills/write-article/TOPICS.md
+++ b/skills/write-article/TOPICS.md
@@ -1,0 +1,58 @@
+# Topics — published log & backlog
+
+**Check this before writing.** Don't repeat a published topic *or a close
+angle*. After publishing, move the topic to "Published" with its slug and a
+one-line note on the angle so future writers (human or AI) don't collide.
+
+Keep formats varied across the catalog: explainers, beginner guides,
+opinion/analysis, curated lists, format/industry deep-dives, and
+how-the-site-works pieces.
+
+---
+
+## Published
+
+| Slug | Title | Format | Angle (don't repeat) |
+|---|---|---|---|
+| `manga-vs-manhwa-vs-manhua` | Manga vs Manhwa vs Manhua: What's Actually Different? | Explainer | Country-of-origin → format/color/reading-direction/genre tendencies |
+| `how-toon-ranks-scores-series` | How Toon Ranks Scores and Ranks Series | How-the-site-works | Category-based scoring vs single star rating; harder to game |
+| `where-to-start-with-manhwa` | Where to Start with Manhwa: A Beginner's Guide | Beginner guide | Webtoon format + sub-genres + how to pick a first read |
+| `completed-series-worth-binging` | Completed Series Worth Binging in One Sitting | Curated/guide | Using "completed" status + category scores to pick safe binges |
+
+---
+
+## Backlog (candidate topics)
+
+Pick one, confirm it doesn't overlap the published angles, then write. Remove or
+move it here once published.
+
+**Explainers**
+- What is a webtoon? Vertical-scroll format vs traditional paged comics.
+- Reading order & terminology newcomers trip on (chapters vs episodes, seasons, hiatus vs cancelled).
+- Color vs black-and-white: why the format choice shapes the art.
+
+**Beginner / how-to guides**
+- How to find your next series when you've "read everything good."
+- How to build and share a reading list on Toon Ranks (ties to `/my-lists`).
+- Using the Compare tool to decide between two series (ties to `/compare`).
+
+**Opinion / analysis**
+- Why community category scores beat a single star rating (reader-facing angle, distinct from the how-it-works piece).
+- The "power fantasy" boom: what regression/leveling/tower stories get right (and where they get samey).
+- What makes a satisfying ending — and why finished series are worth prioritizing.
+
+**Genre / sub-genre spotlights**
+- Regression stories explained: the appeal and the best entry points.
+- Cultivation & xianxia for newcomers (manhua-leaning).
+- Romance manhwa: sub-genres and what sets the great ones apart.
+
+**Format / industry**
+- How official translations and simulpubs work (high level, evergreen).
+- Why so many manhwa are full-color and phone-first.
+
+**How-the-site-works**
+- How Cred Points and the Rankers leaderboard work (ties to `/leaderboard`).
+- How rating across categories works, from a voter's perspective (ties to `/how-rankings-work`).
+
+> Add new ideas here as they come up. Keep each one a *distinct* angle — if it
+> overlaps something published or already in the backlog, sharpen it or drop it.

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -45,6 +45,11 @@ const Footer = () => {
                 </a>
               </li>
               <li>
+                <a href="/articles" className={footerLinkClass}>
+                  Articles
+                </a>
+              </li>
+              <li>
                 <a href="/contact" className={footerLinkClass}>
                   Contact
                 </a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -279,6 +279,9 @@ const Header = () => {
             <NavLink to="/leaderboard" className={desktopNavLink}>
               Leaderboard
             </NavLink>
+            <NavLink to="/articles" className={desktopNavLink}>
+              Articles
+            </NavLink>
           </nav>
         </div>
 
@@ -606,6 +609,7 @@ const Header = () => {
                   { to: "/type/MANHUA", label: "Manhua" },
                   { to: "/forum", label: "Forum" },
                   { to: "/leaderboard", label: "Leaderboard" },
+                  { to: "/articles", label: "Articles" },
                 ].map((item) => (
                   <NavLink
                     key={item.label}

--- a/src/content/articles.ts
+++ b/src/content/articles.ts
@@ -1,0 +1,218 @@
+// Editorial articles for the /articles section.
+//
+// Phase 1: content lives in-repo as original Markdown. The public pages render
+// from this module via getAllArticles()/getArticleBySlug(). The rendering layer
+// is intentionally data-source-agnostic, so a future admin-authored CMS
+// (backend Article model + endpoints) can replace this source without touching
+// the article pages, routes, or SEO/structured-data wiring.
+
+export interface Article {
+  slug: string;
+  title: string;
+  description: string;
+  author: string;
+  /** ISO date strings. */
+  publishedAt: string;
+  updatedAt: string;
+  tags: string[];
+  /**
+   * Optional hero image. Use only images you own or license (or royalty-free) —
+   * never copyrighted manga/manhwa art. Path is served from /public, or an
+   * absolute URL. When omitted, the article renders cleanly text-only.
+   */
+  image?: { src: string; alt: string };
+  /** Original long-form body in Markdown. */
+  body: string;
+}
+
+const AUTHOR = "The Toon Ranks Team";
+
+export const articles: Article[] = [
+  {
+    slug: "manga-vs-manhwa-vs-manhua",
+    title: "Manga vs Manhwa vs Manhua: What's Actually Different?",
+    description:
+      "Manga, manhwa, and manhua look similar at a glance but come from different countries and reading traditions. Here's how to tell them apart and what each format does best.",
+    author: AUTHOR,
+    publishedAt: "2026-06-02",
+    updatedAt: "2026-06-02",
+    tags: ["Guides", "Manga", "Manhwa", "Manhua"],
+    body: `If you've spent any time in comment sections or ranking lists, you've seen the three words used almost interchangeably: **manga**, **manhwa**, and **manhua**. They're related, but they aren't the same thing — and knowing the difference makes it much easier to find series you'll actually enjoy.
+
+## The short version
+
+All three are comics from East Asia, and the words literally translate to roughly the same thing ("comics" or "impromptu sketches"). The distinction is mostly about **country of origin**:
+
+- **Manga** comes from **Japan**.
+- **Manhwa** comes from **South Korea**.
+- **Manhua** comes from **China** (and Chinese-speaking regions like Hong Kong and Taiwan).
+
+That single fact drives almost every other difference below, because each country developed its own publishing industry, art conventions, and reading habits.
+
+## How you read them
+
+The most practical difference is direction. **Manga is read right-to-left** — pages and panels flow the opposite way from Western books, which trips up a lot of newcomers. **Manhwa and manhua are generally read left-to-right**, partly because so many of them were designed for phones first.
+
+That phone-first design is why a huge share of modern manhwa are **webtoons**: long vertical strips you scroll through one continuous column at a time, rather than flipping pages laid out in a grid. Manhua increasingly use the same vertical format.
+
+## Color and art style
+
+Traditional **manga is usually black and white**. That isn't a budget compromise — it's an aesthetic the medium has refined for decades, with screentones and linework doing the work color would do elsewhere. **Manhwa and manhua are frequently in full color**, again because the webtoon format and digital-first distribution made color practical and expected.
+
+Art styles differ too, though there's huge overlap and plenty of exceptions:
+
+- Manga spans an enormous range, from minimalist slice-of-life to dense, detailed action.
+- Manhwa is often associated with clean, polished character art and dramatic, cinematic paneling — especially in popular action and fantasy series.
+- Manhua frequently leans into vibrant color and wuxia/xianxia (martial-arts and cultivation) settings.
+
+## Genres and storytelling
+
+Each tradition has its signatures. Manga covers basically every genre imaginable and has the longest history, so its catalog is the deepest. Manhwa has driven a lot of the recent global boom in **regression, leveling-up, and tower-climbing** power fantasies, alongside strong romance and drama. Manhua is a go-to for **cultivation and historical fantasy**.
+
+None of these are rules — there are slow, quiet manhwa and frenetic action manga. They're tendencies, not boundaries.
+
+## So which should you read?
+
+Whichever tells a story you like. The format label tells you something about presentation (page vs. scroll, color vs. black-and-white) and a bit about genre tendencies, but a great series is a great series. If you're browsing rankings on Toon Ranks, you can filter by type — **manga, manhwa, or manhua** — and compare titles side by side to see what fits your taste before you commit.
+
+The takeaway: the words aren't interchangeable, but they're also not a hierarchy. They're three neighboring traditions that have been borrowing from each other for years — and readers are the ones who benefit.`,
+  },
+  {
+    slug: "how-toon-ranks-scores-series",
+    title: "How Toon Ranks Scores and Ranks Series",
+    description:
+      "Toon Ranks rankings aren't a single star rating — they're built from community votes across multiple categories. Here's exactly how a score is calculated and why it's harder to game.",
+    author: AUTHOR,
+    publishedAt: "2026-06-08",
+    updatedAt: "2026-06-08",
+    tags: ["Guides", "Rankings", "Community"],
+    body: `Most sites boil a series down to one number: a 1-to-5 star average. It's simple, but it hides a lot. A title with gorgeous art and a weak ending gets the same blurry "4 stars" as one that's the reverse. Toon Ranks is built to keep that detail, so here's exactly how our scores work.
+
+## Scores come from categories, not a single tap
+
+When a member rates a series, they don't give one overall score. They rate it across several **distinct categories** — things like story, characters, art, world-building, and the drama or action that carries it. Each category is scored on its own.
+
+This matters because it separates *why* people like (or don't like) a series. A community can collectively say "the art is incredible but the pacing drags," and that nuance survives into the final number instead of being averaged into mush.
+
+## How the final score is calculated
+
+For each category, we take the **average of every member's vote** in that category. Then the series' overall score is the **average of those category averages**.
+
+Averaging the category averages — rather than dumping every individual vote into one pile — keeps any single category from dominating just because it happened to get more votes. Story, art, and characters each get a fair say in the final result.
+
+## Why this is harder to game
+
+Single-number ratings are easy to brigade: a wave of 5s or 1s swings the average fast. A category system is more resistant, because a vote has to be cast across the board, and the structure makes lopsided manipulation stand out. Combined with community moderation, it keeps rankings closer to genuine consensus.
+
+It also rewards series that are **well-rounded**. A title that's merely "pretty" won't ride its art to the top if its story and characters lag — and a narratively brilliant series with rough art still gets credit where it's due.
+
+## Reading a Toon Ranks score
+
+When you see a score on a card or a series page, that number is the rolled-up community verdict across all categories. On the full series page you can see the breakdown, so you're never stuck guessing what the number actually means. Want to weigh two contenders? The **compare** tool puts titles side by side so you can see exactly where each one wins.
+
+## The Rankers leaderboard
+
+Scoring is only half of it. Members who contribute thoughtful ratings and participate in the community earn **Cred Points**, which feed the Rankers leaderboard. The goal is simple: the people shaping the rankings are the people who actually show up and engage, not anonymous drive-by votes.
+
+That's the whole philosophy — a ranking should reflect a real community's considered opinion, with enough structure that the number means something. The more members rate and discuss, the sharper the rankings get.`,
+  },
+  {
+    slug: "where-to-start-with-manhwa",
+    title: "Where to Start with Manhwa: A Beginner's Guide",
+    description:
+      "New to manhwa and not sure where to jump in? Here's how the format works, the sub-genres worth knowing, and how to find a first series that fits your taste.",
+    author: AUTHOR,
+    publishedAt: "2026-06-12",
+    updatedAt: "2026-06-12",
+    tags: ["Guides", "Manhwa", "Beginners"],
+    body: `Manhwa — comics from South Korea — has pulled in a massive global audience over the last few years, and a lot of that is thanks to the webtoon format. If you've been meaning to try it but don't know where to start, this guide will get you oriented fast.
+
+## First, the format
+
+Most modern manhwa are **webtoons**: you read them as a single vertical strip, scrolling down through one continuous column instead of flipping paginated spreads. They're usually in **full color** and read **left-to-right**, which makes them friendlier for first-timers than right-to-left black-and-white manga.
+
+Practically, that means manhwa is built for phones. Short, momentum-driven chapters are the norm, which is part of why the format is so easy to binge.
+
+## Know the big sub-genres
+
+Manhwa covers everything, but a few categories dominate the popular charts. Knowing them helps you pick a lane:
+
+- **Regression** — a character dies or fails, then wakes up in the past with their memories, and tries to do it right this time. Heavy on strategy and payoff.
+- **Leveling-up / progression** — a weak protagonist grows stronger through a clear system (stats, ranks, dungeons). Satisfying, fast-moving power fantasy.
+- **Tower / dungeon climbing** — characters ascend floors or clear gates, each with new challenges and stakes.
+- **Romance and drama** — from office romance to historical settings, often with sharp art and strong character writing.
+- **Revenge and villainess stories** — a wronged lead methodically turns the tables.
+
+You don't need to memorize these — but recognizing them on a ranking page tells you a lot about what you're getting into.
+
+## How to pick your first one
+
+A few tips that save you from bouncing off the wrong title:
+
+1. **Start with something completed or well into its run.** You'll get a full arc instead of waiting on weekly chapters.
+2. **Match the sub-genre to your mood.** Want catharsis? Try a regression or revenge story. Want comfort? Romance or slice-of-life.
+3. **Use the community, not just the cover.** A striking cover doesn't guarantee a good story. Check where a series ranks and what readers actually praise.
+
+## Let the rankings do the work
+
+This is exactly what Toon Ranks is for. Filter the rankings to **manhwa**, sort by score, and you've got a shortlist of community-vetted starting points. Open a series page to see how it scores on story, art, and characters specifically — so you can tell the "gorgeous but shallow" titles from the ones that hold up. When two look tempting, drop them into **compare** and decide.
+
+Start with one well-ranked series in a sub-genre that matches your mood, and you'll understand the appeal within a few chapters. From there, the rabbit hole is deep — in the best way.`,
+  },
+  {
+    slug: "completed-series-worth-binging",
+    title: "Completed Series Worth Binging in One Sitting",
+    description:
+      "No cliffhangers, no waiting on weekly chapters — just finished stories you can read start to end. Here's how to find the best completed manga, manhwa, and manhua.",
+    author: AUTHOR,
+    publishedAt: "2026-06-15",
+    updatedAt: "2026-06-15",
+    tags: ["Recommendations", "Completed", "Binge"],
+    body: `There's a particular joy in a **finished** series. No theorizing about an ending that may never come, no waiting a week between chapters — just a complete story you can read at your own pace, all the way through. If that's the itch you're scratching, here's how to find the best completed titles and what to look for.
+
+## Why "completed" is its own filter
+
+A great ongoing series can still disappoint if it fizzles or goes on hiatus. A **completed** one has already crossed the finish line: the pacing, the payoff, and the ending are all known quantities that the community has rated *as a whole*. That makes finished series some of the safest, most satisfying recommendations you can get.
+
+On Toon Ranks you can filter the rankings by **status**, so you can pull up titles marked complete and sort them by community score — an instant shortlist of stories you can start and actually finish.
+
+## What makes a series binge-worthy
+
+Not every finished story is a great binge. The ones that are tend to share a few traits:
+
+- **A strong, consistent core.** Look at how a series scores on *story* and *characters* specifically, not just the overall number. A binge lives or dies on momentum.
+- **An ending people praise.** The fastest way to ruin a weekend read is a rushed or hollow finale. Community discussion is your early warning system here.
+- **A length that matches your time.** Some completed series are tight and punchy; others are epics. Check the scope before you commit a Saturday to it.
+
+## How to build your own binge list
+
+Here's a simple workflow:
+
+1. Filter rankings to **completed** status (and a type — manga, manhwa, or manhua — if you have a preference).
+2. Sort by score and open the top few series pages.
+3. Read the **category breakdown** to confirm the story and characters land, not just the art.
+4. **Compare** your finalists side by side, then save the winner to a reading list so you don't lose it.
+
+## The payoff
+
+A finished, highly-rated series is the closest thing to a guaranteed good time in this hobby. You skip the gamble of an unfinished story and go straight to the part where you get swept up in something that already knows how to end.
+
+Pull up the completed rankings, trust the category scores, and pick the one that matches your mood — then clear your schedule.`,
+  },
+];
+
+const WORDS_PER_MINUTE = 200;
+
+export function readingTimeMinutes(article: Article): number {
+  const words = article.body.split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / WORDS_PER_MINUTE));
+}
+
+export function getAllArticles(): Article[] {
+  // Newest first.
+  return [...articles].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+}
+
+export function getArticleBySlug(slug: string): Article | undefined {
+  return articles.find((a) => a.slug === slug);
+}

--- a/src/pages/ArticlePage.tsx
+++ b/src/pages/ArticlePage.tsx
@@ -1,0 +1,177 @@
+import { Link, useLoaderData } from "react-router-dom";
+import type { LoaderFunctionArgs } from "react-router";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkBreaks from "remark-breaks";
+import { absoluteUrl, SITE_NAME, SITE_ORIGIN, DEFAULT_SOCIAL_IMAGE } from "../config/site";
+import {
+  getArticleBySlug,
+  readingTimeMinutes,
+  type Article,
+} from "../content/articles";
+
+type ArticleLoaderData = { article: Article };
+
+// SSR loader: resolve the article on the server so the full text is in the
+// initial HTML. Unknown slugs return a real 404 (not a soft-404 200).
+export async function loader({ params }: LoaderFunctionArgs): Promise<ArticleLoaderData> {
+  const article = getArticleBySlug(params.slug ?? "");
+  if (!article) {
+    throw new Response("Article not found", { status: 404 });
+  }
+  return { article };
+}
+
+export function meta({ data }: { data?: ArticleLoaderData }) {
+  const article = data?.article;
+  if (!article) {
+    return [
+      { title: `Article not found | ${SITE_NAME}` },
+      { name: "robots", content: "noindex, nofollow" },
+    ];
+  }
+  const url = absoluteUrl(`/articles/${article.slug}`);
+  const title = `${article.title} | ${SITE_NAME}`;
+  const image = article.image
+    ? article.image.src.startsWith("http")
+      ? article.image.src
+      : absoluteUrl(article.image.src)
+    : DEFAULT_SOCIAL_IMAGE;
+  return [
+    { title },
+    { name: "description", content: article.description },
+    { tagName: "link", rel: "canonical", href: url },
+    { property: "og:title", content: article.title },
+    { property: "og:description", content: article.description },
+    { property: "og:url", content: url },
+    { property: "og:type", content: "article" },
+    { property: "article:published_time", content: article.publishedAt },
+    { property: "article:modified_time", content: article.updatedAt },
+    { property: "og:image", content: image },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: article.title },
+    { name: "twitter:description", content: article.description },
+    { name: "twitter:image", content: image },
+    {
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        headline: article.title,
+        description: article.description,
+        datePublished: article.publishedAt,
+        dateModified: article.updatedAt,
+        author: { "@type": "Organization", name: article.author },
+        publisher: {
+          "@type": "Organization",
+          name: SITE_NAME,
+          url: SITE_ORIGIN,
+          logo: { "@type": "ImageObject", url: DEFAULT_SOCIAL_IMAGE },
+        },
+        image,
+        mainEntityOfPage: { "@type": "WebPage", "@id": url },
+        keywords: article.tags.join(", "),
+      },
+    },
+  ];
+}
+
+function formatDate(iso: string): string {
+  // timeZone: "UTC" so a YYYY-MM-DD renders as the intended calendar date and
+  // stays identical between SSR (server TZ) and client (avoids hydration drift).
+  return new Date(`${iso}T00:00:00Z`).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function ArticlePage() {
+  const { article } = useLoaderData() as ArticleLoaderData;
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-10 sm:px-6 sm:py-12">
+      <Link
+        to="/articles"
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 transition hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
+      >
+        ← All articles
+      </Link>
+
+      <article className="mt-6">
+        <header className="border-b border-slate-200 pb-6 dark:border-[#322922]">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium text-slate-500 dark:text-slate-400">
+            <span>{formatDate(article.publishedAt)}</span>
+            <span aria-hidden="true">·</span>
+            <span>{readingTimeMinutes(article)} min read</span>
+            <span aria-hidden="true">·</span>
+            <span>{article.author}</span>
+          </div>
+          <h1 className="mt-3 text-3xl font-black tracking-tight text-slate-950 dark:text-white sm:text-4xl">
+            {article.title}
+          </h1>
+          <p className="mt-3 text-lg leading-7 text-slate-600 dark:text-slate-300">
+            {article.description}
+          </p>
+        </header>
+
+        {article.image && (
+          <img
+            src={article.image.src}
+            alt={article.image.alt}
+            className="mt-8 aspect-[16/9] w-full rounded-2xl border border-slate-200 object-cover dark:border-[#322922]"
+            loading="lazy"
+          />
+        )}
+
+        <div className="prose prose-slate mt-8 max-w-none dark:prose-invert prose-headings:font-black prose-headings:tracking-tight prose-a:text-blue-600 dark:prose-a:text-blue-300 prose-img:rounded-xl">
+          <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]}>
+            {article.body}
+          </ReactMarkdown>
+        </div>
+
+        <div className="mt-8 flex flex-wrap gap-2 border-t border-slate-200 pt-6 dark:border-[#322922]">
+          {article.tags.map((tag) => (
+            <span
+              key={tag}
+              className="rounded-full bg-slate-100 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:bg-[#241d19] dark:text-slate-400"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </article>
+
+      {/* Internal links back into the product — gives crawlers paths and readers a next step. */}
+      <div className="mt-10 rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm dark-theme-card">
+        <h2 className="text-lg font-black text-slate-950 dark:text-white">
+          Find your next series
+        </h2>
+        <p className="mt-1 text-sm leading-6 text-slate-600 dark:text-slate-300">
+          Browse community rankings for manga, manhwa, and manhua, or see how the
+          scores are calculated.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Link
+            to="/"
+            className="rounded-full bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+          >
+            Browse rankings
+          </Link>
+          <Link
+            to="/how-rankings-work"
+            className="rounded-full border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 dark:border-[#3a3028] dark:text-slate-300 dark:hover:bg-[#241d19]"
+          >
+            How rankings work
+          </Link>
+          <Link
+            to="/articles"
+            className="rounded-full border border-slate-300 px-5 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 dark:border-[#3a3028] dark:text-slate-300 dark:hover:bg-[#241d19]"
+          >
+            More articles
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ArticlesIndexPage.tsx
+++ b/src/pages/ArticlesIndexPage.tsx
@@ -1,0 +1,114 @@
+import { Link } from "react-router-dom";
+import { absoluteUrl, SITE_NAME, SITE_ORIGIN } from "../config/site";
+import { getAllArticles, readingTimeMinutes } from "../content/articles";
+
+const PAGE_TITLE = `Articles | ${SITE_NAME}`;
+const PAGE_DESCRIPTION =
+  "Guides, explainers, and recommendations for manga, manhwa, and manhua readers — from the Toon Ranks community.";
+
+export function meta() {
+  const articles = getAllArticles();
+  return [
+    { title: PAGE_TITLE },
+    { name: "description", content: PAGE_DESCRIPTION },
+    { property: "og:title", content: PAGE_TITLE },
+    { property: "og:description", content: PAGE_DESCRIPTION },
+    { property: "og:url", content: absoluteUrl("/articles") },
+    { property: "og:type", content: "website" },
+    { name: "twitter:card", content: "summary" },
+    {
+      "script:ld+json": {
+        "@context": "https://schema.org",
+        "@type": "Blog",
+        name: `${SITE_NAME} Articles`,
+        url: absoluteUrl("/articles"),
+        publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_ORIGIN },
+        blogPost: articles.map((a) => ({
+          "@type": "BlogPosting",
+          headline: a.title,
+          description: a.description,
+          datePublished: a.publishedAt,
+          dateModified: a.updatedAt,
+          author: { "@type": "Organization", name: a.author },
+          url: absoluteUrl(`/articles/${a.slug}`),
+        })),
+      },
+    },
+  ];
+}
+
+export function links() {
+  return [{ rel: "canonical", href: absoluteUrl("/articles") }];
+}
+
+function formatDate(iso: string): string {
+  // timeZone: "UTC" so a YYYY-MM-DD renders as the intended calendar date and
+  // stays identical between SSR (server TZ) and client (avoids hydration drift).
+  return new Date(`${iso}T00:00:00Z`).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function ArticlesIndexPage() {
+  const articles = getAllArticles();
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6 sm:py-12">
+      <header className="mb-8">
+        <p className="text-xs font-bold uppercase tracking-[0.24em] text-blue-600 dark:text-blue-300">
+          {SITE_NAME}
+        </p>
+        <h1 className="mt-3 text-4xl font-black tracking-tight text-slate-950 dark:text-white sm:text-5xl">
+          Articles
+        </h1>
+        <p className="mt-4 max-w-2xl text-base leading-7 text-slate-600 dark:text-slate-300">
+          Guides, explainers, and recommendations for manga, manhwa, and manhua
+          readers — written by the Toon Ranks community.
+        </p>
+      </header>
+
+      <div className="space-y-4">
+        {articles.map((article) => (
+          <Link
+            key={article.slug}
+            to={`/articles/${article.slug}`}
+            className="group block rounded-[28px] border border-slate-200 bg-white p-6 shadow-sm transition hover:border-slate-300 hover:shadow-md dark-theme-card sm:p-7"
+          >
+            {article.image && (
+              <img
+                src={article.image.src}
+                alt={article.image.alt}
+                className="mb-4 aspect-[16/9] w-full rounded-2xl object-cover"
+                loading="lazy"
+              />
+            )}
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs font-medium text-slate-500 dark:text-slate-400">
+              <span>{formatDate(article.publishedAt)}</span>
+              <span aria-hidden="true">·</span>
+              <span>{readingTimeMinutes(article)} min read</span>
+            </div>
+            <h2 className="mt-2 text-xl font-black tracking-tight text-slate-950 transition group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-300 sm:text-2xl">
+              {article.title}
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">
+              {article.description}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {article.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full bg-slate-100 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:bg-[#241d19] dark:text-slate-400"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -30,12 +30,15 @@ export default [
   route("forum", "pages/ForumPage.tsx"),
   route("forum/:id", "pages/ThreadPage.tsx"),
   route("lists/:token", "pages/PublicReadingListPage.tsx"),
+  route("articles", "pages/ArticlesIndexPage.tsx"),
+  route("articles/:slug", "pages/ArticlePage.tsx"),
 
   // Sitemap proxies (resource routes) — replicate the old Amplify rewrites that
   // served these XML files from the backend on the www host. Must be registered
   // before the "*" catch-all so they aren't swallowed by it.
   route("sitemap.xml", "sitemap/sitemapIndex.ts"),
   route("sitemap-static.xml", "sitemap/sitemapStatic.ts"),
+  route("sitemap-articles.xml", "sitemap/sitemapArticles.ts"),
   route("sitemaps/*", "sitemap/sitemapsSplat.ts"),
 
   route("*", "pages/NotFoundPage.tsx"),

--- a/src/sitemap/sitemapArticles.ts
+++ b/src/sitemap/sitemapArticles.ts
@@ -1,0 +1,38 @@
+import { absoluteUrl } from "../config/site";
+import { getAllArticles } from "../content/articles";
+
+// Resource route for /sitemap-articles.xml. Articles are defined in the
+// frontend (src/content/articles.ts), so the backend-proxied sitemaps can't
+// include them — this generates their <urlset> here. Declared in robots.txt so
+// crawlers discover it.
+export function loader(): Response {
+  const articles = getAllArticles();
+  const urls = [
+    { loc: absoluteUrl("/articles"), lastmod: articles[0]?.updatedAt },
+    ...articles.map((a) => ({
+      loc: absoluteUrl(`/articles/${a.slug}`),
+      lastmod: a.updatedAt,
+    })),
+  ];
+
+  const body =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    urls
+      .map(
+        (u) =>
+          `  <url>\n    <loc>${u.loc}</loc>` +
+          (u.lastmod ? `\n    <lastmod>${u.lastmod}</lastmod>` : "") +
+          `\n  </url>`
+      )
+      .join("\n") +
+    `\n</urlset>\n`;
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Public SSR /articles section (index + article pages, JSON-LD, SEO, nav links)
  with 4 original launch articles; ads.txt.
- skills/ : AI-agnostic, discoverable task playbooks. write-article (house
  standard + workflow) and generate-article-image (original royalty-free,
  on-brand images). Usable by any AI that can read the repo; a .claude/skills
  pointer keeps Claude Code's slash-command working. CLAUDE.md points to skills/.

## Test plan
- [ ] "use the write-article skill" → AI finds skills/write-article/SKILL.md and follows it
- [ ] /articles renders; new articles added via src/content/articles.ts appear
- [ ] generate-article-image produces an on-brand, license-safe image or sourcing guidance