### PR TITLE
update uat

### DIFF
--- a/src/components/ManCard.tsx
+++ b/src/components/ManCard.tsx
@@ -183,7 +183,7 @@ const ManCard = ({
           </div>
 
           <div className="mt-3 flex flex-1 flex-col gap-2 px-2 pb-2 sm:mt-4 sm:px-2.5">
-            <h2 className="line-clamp-2 min-h-[2.6rem] w-full text-[15px] font-semibold leading-5 text-slate-900 dark:text-white sm:text-base sm:leading-normal" title={title}>
+            <h2 className="line-clamp-1 w-full text-[15px] font-semibold leading-5 text-slate-900 dark:text-white sm:text-base sm:leading-normal" title={title}>
               {title}
             </h2>
 


### PR DESCRIPTION
## Summary
- ManCard title: line-clamp-2 + min-h-[2.6rem] -> line-clamp-1 (single line,
  ellipsis on overflow; full title on hover). Matches the mobile card.
- Alignment unaffected: the gap-2 + mt-auto layout keeps action rows bottom-
  aligned now that all titles are one line.

## Test plan
- [ ] Long titles truncate to one line; short titles unchanged
- [ ] Compare/Save rows align across cards (1- vs 2-line credits)
- [ ] Mobile + desktop both fine