### PR TITLE
new article

### DIFF
--- a/skills/write-article/TOPICS.md
+++ b/skills/write-article/TOPICS.md
@@ -19,6 +19,7 @@ how-the-site-works pieces.
 | `where-to-start-with-manhwa` | Where to Start with Manhwa: A Beginner's Guide | Beginner guide | Webtoon format + sub-genres + how to pick a first read |
 | `completed-series-worth-binging` | Completed Series Worth Binging in One Sitting | Curated/guide | Using "completed" status + category scores to pick safe binges |
 | `what-is-a-webtoon` | What Is a Webtoon? The Vertical-Scroll Format, Explained | Explainer | The vertical-scroll / infinite-canvas format (color, phone-first, episodic) vs origin; why it spread |
+| `regression-stories-explained` | Regression Stories Explained: The Appeal and the Catch | Genre spotlight | Regression vs reincarnation/isekai; foreknowledge as a fragile engine; how category scores spot the good ones |
 
 ---
 
@@ -42,7 +43,6 @@ move it here once published.
 - What makes a satisfying ending — and why finished series are worth prioritizing.
 
 **Genre / sub-genre spotlights**
-- Regression stories explained: the appeal and the best entry points.
 - Cultivation & xianxia for newcomers (manhua-leaning).
 - Romance manhwa: sub-genres and what sets the great ones apart.
 

--- a/src/content/articles.ts
+++ b/src/content/articles.ts
@@ -246,6 +246,53 @@ Format tells you how a series reads; it says nothing about whether it's any good
 
 Read a couple and the format stops being a novelty. You're just reading, which is the whole point.`,
   },
+  {
+    slug: "regression-stories-explained",
+    title: "Regression Stories Explained: The Appeal and the Catch",
+    description:
+      "Regression stories send a hero back in time with memories intact. Why the do-over premise hooks readers, where it goes wrong, and how to find the best.",
+    author: AUTHOR,
+    publishedAt: "2026-06-27",
+    updatedAt: "2026-06-27",
+    tags: ["Guides", "Manhwa", "Recommendations"],
+    body: `A character dies on the last page, betrayed or broken or just out of time. Then they open their eyes ten years earlier, back in a childhood bedroom, with every memory of how it all went wrong still intact. That's a regression story, and once you notice the pattern you'll see it everywhere in manhwa.
+
+The hook is simple, and it's one of the most reliable setups in modern webtoons. Here's why it works so well, where it tends to fall apart, and how to find the ones worth your time.
+
+## What regression actually means
+
+Regression is time travel stripped down to its most personal form. The protagonist doesn't visit a distant era or wake up as a stranger. They go back to their own past and keep the knowledge they earned the hard way. Sometimes it's a single rewind. Sometimes they loop the same stretch of years over and over until they finally get it right.
+
+It overlaps with two cousins you'll also see tagged constantly: reincarnation, where the hero is reborn as someone new, and the transfer into a game or another world entirely. Regression is the one where the stakes feel closest to home, because the character already lived this life and lost it.
+
+## Why the setup hooks you
+
+A regressor walks into chapter one already knowing the ending. They know which ally turns traitor, which harmless-looking kid becomes a monster, which safe bet collapses. The fun isn't watching them discover the world. It's watching them weaponize information nobody else has.
+
+That flips the usual underdog rhythm. Most power-fantasy leads claw their way up from nothing. A regressor starts with a map of every trap. The tension moves from "can they win" to "how badly will they wreck the people who beat them last time," and that's a sharper kind of satisfaction.
+
+There's an emotional layer too, when the writer bothers with it. Going back means seeing people who are alive again: the mentor who died, the friend who didn't make it. A good regression story treats the second chance as something that costs the hero, not just a cheat code.
+
+## The catch
+
+Here's where a lot of these series get samey. Foreknowledge is a fragile engine. Once the protagonist has changed enough of the timeline, their memory of what comes next stops being worth much, and a lazy story just hands them a fresh convenient vision whenever the plot needs a push.
+
+The other failure mode is stakes. If the hero is smarter, stronger, and pre-informed, what's left to threaten them? The weaker entries turn into a victory lap where the lead steamrolls every old enemy with no suspense. The strong ones keep the pressure on by letting the world react. Change the past and you get new problems the regressor never saw coming, because this timeline isn't the one they remember.
+
+So the question that separates a great regression manhwa from a forgettable one is usually this: does the foreknowledge run out, and does the story make the hero earn the rest?
+
+## How to find the good ones
+
+Because the subgenre is so crowded, the floor is low and the ceiling is high, and the tags alone won't tell you which is which. This is where community scores help more than a back-cover blurb. On the [manhwa rankings](/type/MANHWA), where most of these live, the category breakdown is the tell: a regression series that rates well on story and characters, not just art or action, is usually one where the writing keeps up with the premise.
+
+Stuck between two? Drop them into [Compare](/compare) and look at where the scores split. A big gap on the story axis is exactly the difference between a tight plan-it-all thriller and a repetitive power trip. And if you want to know why those category averages are harder to fake than a single star rating, the breakdown of [how Toon Ranks scores series](/how-rankings-work) walks through it.
+
+New to webtoons in general? Regression makes a great on-ramp, but our [beginner's guide to manhwa](/articles/where-to-start-with-manhwa) covers the format basics first.
+
+## The second chance only counts if it can fail
+
+Regression endures because it scratches a specific itch: the fantasy of knowing exactly what you'd do differently, and finally getting the shot. The best ones never forget that a do-over means nothing if it can't still go wrong. Find one that keeps the danger alive, and the premise stops feeling like a gimmick and starts feeling like a story.`,
+  },
 ];
 
 const WORDS_PER_MINUTE = 200;


### PR DESCRIPTION
Adds a new original /articles piece, "Regression Stories Explained: The Appeal and the Catch," a genre spotlight on the regression subgenre (appeal, common pitfalls, and using category scores to find strong entries). Written to the house authoring standard with four internal links; logged in TOPICS.md. Builds clean and server-renders. Part of growing original editorial content to strengthen AdSense approval.