### PR TITLE
Frontend series related articles

### DIFF
--- a/src/components/RelatedArticles.tsx
+++ b/src/components/RelatedArticles.tsx
@@ -1,0 +1,55 @@
+import { Link } from "react-router-dom";
+import { getRelatedArticles, readingTimeMinutes } from "../content/articles";
+
+/**
+ * "From the blog" module shown on a series page. Surfaces a few relevant
+ * articles (preferring the series' type) to give readers a next step and to
+ * build internal links between series pages and editorial content (SEO + AdSense
+ * value). Renders nothing when there are no articles to show.
+ */
+export default function RelatedArticles({ seriesType }: { seriesType?: string }) {
+  const articles = getRelatedArticles(seriesType, 3);
+  if (articles.length === 0) return null;
+
+  return (
+    <section className="mt-8 overflow-visible rounded-[30px] border border-slate-200 bg-white/95 shadow-[0_24px_60px_-42px_rgba(15,23,42,0.45)] dark-theme-shell">
+      <div className="border-b border-slate-200/80 px-5 py-5 dark:border-[#342a23] sm:px-6">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+          From the blog
+        </p>
+        <h2 className="mt-1 text-2xl font-semibold tracking-tight text-slate-950 dark:text-white">
+          Related reading
+        </h2>
+      </div>
+
+      <div className="grid gap-3 px-5 py-5 sm:grid-cols-2 sm:px-6 lg:grid-cols-3">
+        {articles.map((article) => (
+          <Link
+            key={article.slug}
+            to={`/articles/${article.slug}`}
+            className="group flex flex-col rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md dark-theme-card"
+          >
+            <span className="text-[11px] font-medium text-slate-500 dark:text-slate-400">
+              {readingTimeMinutes(article)} min read
+            </span>
+            <h3 className="mt-1 text-sm font-bold tracking-tight text-slate-950 transition group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-300">
+              {article.title}
+            </h3>
+            <p className="mt-1.5 line-clamp-3 text-xs leading-5 text-slate-600 dark:text-slate-300">
+              {article.description}
+            </p>
+          </Link>
+        ))}
+      </div>
+
+      <div className="px-5 pb-5 sm:px-6">
+        <Link
+          to="/articles"
+          className="text-sm font-semibold text-blue-600 hover:underline dark:text-blue-300"
+        >
+          Browse all articles →
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/content/articles.test.ts
+++ b/src/content/articles.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { getRelatedArticles, getAllArticles } from "./articles";
+
+describe("getRelatedArticles", () => {
+  it("returns at most `limit` articles", () => {
+    expect(getRelatedArticles("MANHWA", 3).length).toBeLessThanOrEqual(3);
+    expect(getRelatedArticles("MANGA", 1)).toHaveLength(1);
+  });
+
+  it("prefers articles tagged for the series type", () => {
+    const manhwa = getRelatedArticles("MANHWA", 3);
+    // At least the first result should carry the matching tag when such
+    // articles exist in the catalog.
+    const taggedManhwa = getAllArticles().filter((a) => a.tags.includes("Manhwa"));
+    if (taggedManhwa.length > 0) {
+      expect(manhwa[0].tags).toContain("Manhwa");
+    }
+  });
+
+  it("tops up with recent articles when there aren't enough matches", () => {
+    // An unknown / untagged type has no matches, so it should still fill up to
+    // the limit from the newest articles rather than returning empty.
+    const result = getRelatedArticles("UNKNOWN", 3);
+    const available = Math.min(3, getAllArticles().length);
+    expect(result).toHaveLength(available);
+  });
+
+  it("never returns duplicate slugs", () => {
+    const slugs = getRelatedArticles("MANHWA", 3).map((a) => a.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("is safe with no series type", () => {
+    expect(() => getRelatedArticles(undefined, 3)).not.toThrow();
+  });
+});

--- a/src/content/articles.ts
+++ b/src/content/articles.ts
@@ -310,3 +310,36 @@ export function getAllArticles(): Article[] {
 export function getArticleBySlug(slug: string): Article | undefined {
   return articles.find((a) => a.slug === slug);
 }
+
+/** Maps a series type (e.g. "MANHWA") to the article tag we use for it. */
+function tagForSeriesType(seriesType?: string): string | undefined {
+  switch ((seriesType ?? "").toUpperCase()) {
+    case "MANGA":
+      return "Manga";
+    case "MANHWA":
+      return "Manhwa";
+    case "MANHUA":
+      return "Manhua";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Articles to surface alongside a series. Prefers pieces tagged for the series'
+ * type (manga/manhwa/manhua); if there aren't enough, tops up with the most
+ * recent articles so the module is never empty when articles exist. Pure and
+ * deterministic (newest-first), so it's safe to call during SSR.
+ */
+export function getRelatedArticles(seriesType?: string, limit = 3): Article[] {
+  const all = getAllArticles();
+  const tag = tagForSeriesType(seriesType);
+
+  const matched = tag ? all.filter((a) => a.tags.includes(tag)) : [];
+  if (matched.length >= limit) return matched.slice(0, limit);
+
+  // Top up with the newest articles not already included, preserving order.
+  const seen = new Set(matched.map((a) => a.slug));
+  const filler = all.filter((a) => !seen.has(a.slug));
+  return [...matched, ...filler].slice(0, limit);
+}

--- a/src/pages/SeriesDetailPage.tsx
+++ b/src/pages/SeriesDetailPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useParams, useLocation, useLoaderData } from "react-router-dom";
 import type { LoaderFunctionArgs } from "react-router";
 import SeriesDetail from "../components/SeriesDetail";
+import RelatedArticles from "../components/RelatedArticles";
 import AddSeriesDetailModal from "../components/AddSeriesDetailModal";
 import {
   getSeriesDetailById,
@@ -531,6 +532,8 @@ const SeriesDetailPage = () => {
                 />
               </div>
             </section>
+
+            <RelatedArticles seriesType={series.type} />
           </>
         )}
 


### PR DESCRIPTION
Adds a "From the blog" module to series pages that surfaces up to three relevant articles (preferring the series' type tag, topping up with recent posts) plus a link to the articles index. Introduces a pure, SSR-safe getRelatedArticles() helper (unit-tested) and a themed RelatedArticles component. Strengthens internal linking between series and editorial content for SEO/AdSense. Builds clean; lint and tests pass.