### PR TITLE
Uat

### DIFF
--- a/docs/FORUM_REDDIT_REFINEMENT.md
+++ b/docs/FORUM_REDDIT_REFINEMENT.md
@@ -111,6 +111,23 @@ These are the product decisions; re-implement them with RN primitives
    (threads list to return `first_post_excerpt`). Do once, both clients
    benefit.
 
+## 3b. Follow-up pass (branch `forum-refinement-followups`)
+
+A second review after the first branch merged found and fixed:
+
+- **Reply-count off-by-one in the personal feeds and thread headers.**
+  `post_count` includes the OP; the Following tab said "N replies" using the
+  raw count. Fixed in `src/components/ForumPersonalFeed.tsx` (and the mobile
+  counterparts) with `max(0, post_count - 1)`.
+- **Personal feeds silently capped at 20.** Following/Bookmarked fetched only
+  page 1. Both lists now accumulate pages with a "Load more" button driven by
+  `has_next`.
+- **Personal feed rows flattened** into the same divided-container style as the
+  Discover feed (one rounded container, hairline dividers, hover bg).
+- **Thread page admin controls behind an overflow.** The Lock / Latest-first
+  pill group in the thread header became a "⋯" menu (`ThreadAdminMenu` in
+  `ThreadPage.tsx`), matching the feed's kebab pattern.
+
 ## 4. Verification done on this branch
 
 - `npm run lint` and `npm run build` clean (pre-existing fast-refresh warnings

--- a/src/components/ForumPersonalFeed.tsx
+++ b/src/components/ForumPersonalFeed.tsx
@@ -53,25 +53,38 @@ function hasMarkdownImage(markdown: string): boolean {
  *
  * Client-only (rendered behind an auth gate), so no SSR/loader wiring needed.
  */
+const PERSONAL_PAGE_SIZE = 20;
+
 export default function ForumPersonalFeed({ view }: { view: PersonalView }) {
   const [threads, setThreads] = useState<ForumThread[]>([]);
   const [posts, setPosts] = useState<ForumPost[]>([]);
+  const [page, setPage] = useState(1);
+  const [hasNext, setHasNext] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
     setError(false);
+    setPage(1);
+    setHasNext(false);
 
     (async () => {
       try {
         if (view === "following") {
-          const res = await fetchMyFollowing(1, 20);
-          if (!cancelled) setThreads(res.items);
+          const res = await fetchMyFollowing(1, PERSONAL_PAGE_SIZE);
+          if (!cancelled) {
+            setThreads(res.items);
+            setHasNext(res.has_next);
+          }
         } else {
-          const res = await fetchMyBookmarks(1, 20);
-          if (!cancelled) setPosts(res.items);
+          const res = await fetchMyBookmarks(1, PERSONAL_PAGE_SIZE);
+          if (!cancelled) {
+            setPosts(res.items);
+            setHasNext(res.has_next);
+          }
         }
       } catch {
         if (!cancelled) setError(true);
@@ -84,6 +97,39 @@ export default function ForumPersonalFeed({ view }: { view: PersonalView }) {
       cancelled = true;
     };
   }, [view]);
+
+  const loadMore = async () => {
+    if (loadingMore || !hasNext) return;
+    setLoadingMore(true);
+    const nextPage = page + 1;
+    try {
+      if (view === "following") {
+        const res = await fetchMyFollowing(nextPage, PERSONAL_PAGE_SIZE);
+        setThreads((prev) => [...prev, ...res.items]);
+        setHasNext(res.has_next);
+      } else {
+        const res = await fetchMyBookmarks(nextPage, PERSONAL_PAGE_SIZE);
+        setPosts((prev) => [...prev, ...res.items]);
+        setHasNext(res.has_next);
+      }
+      setPage(nextPage);
+    } catch {
+      // keep what we have; the button stays for a retry
+    } finally {
+      setLoadingMore(false);
+    }
+  };
+
+  const loadMoreButton = hasNext ? (
+    <button
+      type="button"
+      onClick={loadMore}
+      disabled={loadingMore}
+      className="mt-3 w-full rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-[#3a3028] dark:bg-transparent dark:text-stone-300 dark:hover:bg-[#241d19]"
+    >
+      {loadingMore ? "Loading..." : "Load more"}
+    </button>
+  ) : null;
 
   if (loading) {
     return (
@@ -114,42 +160,52 @@ export default function ForumPersonalFeed({ view }: { view: PersonalView }) {
     }
 
     return (
-      <ul className="space-y-3">
-        {threads.map((t) => (
-          <li key={t.id}>
-            <Link
-              to={`/forum/${t.id}`}
-              className="group block rounded-2xl border border-slate-200/80 bg-white px-4 py-3 transition hover:border-slate-300 hover:shadow-sm dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(27,22,19,0.96),_rgba(21,17,14,0.96))]"
-            >
-              <div className="flex items-center gap-2">
-                <h3 className="min-w-0 flex-1 truncate text-sm font-bold text-slate-900 transition group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-300">
-                  {t.title}
-                </h3>
-                {t.has_unread ? (
-                  <span className="shrink-0 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-blue-700 dark:bg-blue-950/50 dark:text-blue-300">
-                    New
-                  </span>
-                ) : null}
-              </div>
-              <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-slate-500 dark:text-slate-400">
-                <span>
-                  {t.post_count} {t.post_count === 1 ? "reply" : "replies"}
-                </span>
-                <span aria-hidden="true">·</span>
-                <span suppressHydrationWarning>
-                  active {timeAgo(t.last_post_at)}
-                </span>
-                {t.category_name ? (
-                  <>
+      <>
+        {/* Flat divided feed — matches the Discover thread list */}
+        <ul className="overflow-hidden rounded-[1.5rem] border border-slate-200/80 bg-white/70 shadow-sm backdrop-blur-sm dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,rgba(27,22,19,0.98),rgba(20,16,13,0.98))]">
+          {threads.map((t) => {
+            const replyCount = Math.max(0, (t.post_count ?? 1) - 1);
+            return (
+              <li
+                key={t.id}
+                className="border-b border-slate-100 last:border-b-0 dark:border-[#2b231d]"
+              >
+                <Link
+                  to={`/forum/${t.id}`}
+                  className="group block px-4 py-3 transition hover:bg-slate-50/80 dark:hover:bg-[#241d19]"
+                >
+                  <div className="flex items-center gap-2">
+                    <h3 className="min-w-0 flex-1 truncate text-sm font-bold text-slate-900 transition group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-300">
+                      {t.title}
+                    </h3>
+                    {t.has_unread ? (
+                      <span className="shrink-0 rounded-full bg-blue-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-blue-700 dark:bg-blue-950/50 dark:text-blue-300">
+                        New
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-slate-500 dark:text-slate-400">
+                    <span>
+                      {replyCount} {replyCount === 1 ? "reply" : "replies"}
+                    </span>
                     <span aria-hidden="true">·</span>
-                    <span>{t.category_name}</span>
-                  </>
-                ) : null}
-              </div>
-            </Link>
-          </li>
-        ))}
-      </ul>
+                    <span suppressHydrationWarning>
+                      active {timeAgo(t.last_post_at)}
+                    </span>
+                    {t.category_name ? (
+                      <>
+                        <span aria-hidden="true">·</span>
+                        <span>{t.category_name}</span>
+                      </>
+                    ) : null}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+        {loadMoreButton}
+      </>
     );
   }
 
@@ -164,35 +220,42 @@ export default function ForumPersonalFeed({ view }: { view: PersonalView }) {
   }
 
   return (
-    <ul className="space-y-3">
-      {posts.map((p) => {
-        const href = p.thread_id ? `/forum/${p.thread_id}#post-${p.id}` : "/forum";
-        const hasImage = hasMarkdownImage(p.content_markdown);
-        return (
-          <li key={p.id}>
-            <Link
-              to={href}
-              className="group block rounded-2xl border border-slate-200/80 bg-white px-4 py-3 transition hover:border-slate-300 hover:shadow-sm dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(27,22,19,0.96),_rgba(21,17,14,0.96))]"
+    <>
+      {/* Flat divided feed — matches the Discover thread list */}
+      <ul className="overflow-hidden rounded-[1.5rem] border border-slate-200/80 bg-white/70 shadow-sm backdrop-blur-sm dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,rgba(27,22,19,0.98),rgba(20,16,13,0.98))]">
+        {posts.map((p) => {
+          const href = p.thread_id ? `/forum/${p.thread_id}#post-${p.id}` : "/forum";
+          const hasImage = hasMarkdownImage(p.content_markdown);
+          return (
+            <li
+              key={p.id}
+              className="border-b border-slate-100 last:border-b-0 dark:border-[#2b231d]"
             >
-              <div className="flex flex-wrap items-center gap-x-1.5 text-xs text-slate-500 dark:text-slate-400">
-                <span className="font-medium text-slate-700 dark:text-slate-200">
-                  {p.author_username || "Anonymous"}
-                </span>
-                <span aria-hidden="true">·</span>
-                <span suppressHydrationWarning>{timeAgo(p.created_at)}</span>
-                {hasImage ? (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-700 dark:border-sky-800/70 dark:bg-sky-950/30 dark:text-sky-300">
-                    <ImageIcon className="h-3 w-3" aria-hidden="true" />
-                    Image
+              <Link
+                to={href}
+                className="group block px-4 py-3 transition hover:bg-slate-50/80 dark:hover:bg-[#241d19]"
+              >
+                <div className="flex flex-wrap items-center gap-x-1.5 text-xs text-slate-500 dark:text-slate-400">
+                  <span className="font-medium text-slate-700 dark:text-slate-200">
+                    {p.author_username || "Anonymous"}
                   </span>
-                ) : null}
-              </div>
-              <BookmarkedPostPreview markdown={p.content_markdown} />
-            </Link>
-          </li>
-        );
-      })}
-    </ul>
+                  <span aria-hidden="true">·</span>
+                  <span suppressHydrationWarning>{timeAgo(p.created_at)}</span>
+                  {hasImage ? (
+                    <span className="inline-flex items-center gap-1 rounded-full border border-sky-200 bg-sky-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-sky-700 dark:border-sky-800/70 dark:bg-sky-950/30 dark:text-sky-300">
+                      <ImageIcon className="h-3 w-3" aria-hidden="true" />
+                      Image
+                    </span>
+                  ) : null}
+                </div>
+                <BookmarkedPostPreview markdown={p.content_markdown} />
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      {loadMoreButton}
+    </>
   );
 }
 

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -83,13 +83,6 @@ const pillAmber = "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber
 const pillIndigo = "border-indigo-200 bg-indigo-50 text-indigo-800 dark:border-indigo-800 dark:bg-indigo-950/30 dark:text-indigo-300";
 const pillRose = "border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100 dark:border-rose-800 dark:bg-rose-950/30 dark:text-rose-300 dark:hover:bg-rose-950/50";
 
-const ctrlGroup =
-  "flex items-center gap-1 rounded-full border border-gray-200 bg-white p-1 shadow-sm dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(27,22,19,0.96),_rgba(21,17,14,0.96))]";
-const ctrlBtn =
-  "inline-flex items-center gap-1 h-7 px-3 rounded-full text-xs border border-transparent hover:bg-gray-50 text-gray-700 dark:text-slate-200 dark:hover:bg-[#241d19]";
-const ctrlActiveAmber = "bg-amber-50 border-amber-300 text-amber-800 dark:bg-amber-950/40 dark:border-amber-800 dark:text-amber-300";
-const ctrlActiveIndigo = "bg-indigo-50 border-indigo-300 text-indigo-800 dark:bg-indigo-950/40 dark:border-indigo-800 dark:text-indigo-300";
-
 type AxiosLike = {
   message?: string;
   response?: { data?: { detail?: unknown } };
@@ -918,73 +911,42 @@ export default function ThreadPage() {
               </Link>
 
               {isAdmin && (
-                <div className={ctrlGroup}>
-                  <button
-                    type="button"
-                    onClick={async () => {
-                      const next = !thread!.locked;
-                      try {
-                        await lockForumThread(thread!.id, next);
-                        setThread((t) => (t ? { ...t, locked: next } : t));
-                      } catch (e) {
-                        // alert(
-                        //   (e as { message?: string }).message ||
-                        //     "Failed to toggle lock."
-                        // );
-                        notice.show({
-                          message:
-                            (e as { message?: string }).message ||
-                            "Failed to toggle lock.",
-                          title: "Action failed",
-                          variant: "error",
-                        });
-                      }
-                    }}
-                    className={`${ctrlBtn} ${
-                      thread?.locked ? ctrlActiveAmber : ""
-                    }`}
-                    title={thread?.locked ? "Unlock thread" : "Lock thread"}
-                  >
-                    {thread?.locked ? "Unlock" : "Lock"}
-                  </button>
-
-                  <button
-                    type="button"
-                    onClick={async () => {
-                      const next = !thread!.latest_first;
-                      try {
-                        await updateForumThreadSettings(thread!.id, {
-                          latest_first: next,
-                        });
-                        setThread((t) =>
-                          t ? { ...t, latest_first: next } : t
-                        );
-                      } catch (e) {
-                        // alert(
-                        //   (e as { message?: string }).message ||
-                        //     "Failed to update ordering."
-                        // );
-                        notice.show({
-                          message:
-                            (e as { message?: string }).message ||
-                            "Failed to update ordering.",
-                          title: "Action failed",
-                          variant: "error",
-                        });
-                      }
-                    }}
-                    className={`${ctrlBtn} ${
-                      thread?.latest_first ? ctrlActiveIndigo : ""
-                    }`}
-                    title={
-                      thread?.latest_first
-                        ? "Show oldest first"
-                        : "Show latest first"
+                <ThreadAdminMenu
+                  locked={!!thread?.locked}
+                  latestFirst={!!thread?.latest_first}
+                  onToggleLock={async () => {
+                    const next = !thread!.locked;
+                    try {
+                      await lockForumThread(thread!.id, next);
+                      setThread((t) => (t ? { ...t, locked: next } : t));
+                    } catch (e) {
+                      notice.show({
+                        message:
+                          (e as { message?: string }).message ||
+                          "Failed to toggle lock.",
+                        title: "Action failed",
+                        variant: "error",
+                      });
                     }
-                  >
-                    {thread?.latest_first ? "Oldest first" : "Latest first"}
-                  </button>
-                </div>
+                  }}
+                  onToggleLatestFirst={async () => {
+                    const next = !thread!.latest_first;
+                    try {
+                      await updateForumThreadSettings(thread!.id, {
+                        latest_first: next,
+                      });
+                      setThread((t) => (t ? { ...t, latest_first: next } : t));
+                    } catch (e) {
+                      notice.show({
+                        message:
+                          (e as { message?: string }).message ||
+                          "Failed to update ordering.",
+                        title: "Action failed",
+                        variant: "error",
+                      });
+                    }
+                  }}
+                />
               )}
             </div>
           </div>
@@ -1401,6 +1363,85 @@ export default function ThreadPage() {
         variant={notice.variant}
         onClose={notice.hide}
       />
+    </div>
+  );
+}
+
+/** Admin "⋯" overflow for thread-level moderation (Lock, reply ordering). */
+function ThreadAdminMenu({
+  locked,
+  latestFirst,
+  onToggleLock,
+  onToggleLatestFirst,
+}: {
+  locked: boolean;
+  latestFirst: boolean;
+  onToggleLock: () => void;
+  onToggleLatestFirst: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const itemClass =
+    "block w-full px-3 py-2 text-left text-xs font-medium text-slate-600 transition hover:bg-slate-50 dark:text-stone-200 dark:hover:bg-[#241d19]";
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-label="Thread admin actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className={`${pillBase} border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-[#3a3028] dark:bg-transparent dark:text-slate-300 dark:hover:bg-[#241d19]`}
+      >
+        ⋯
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-20 mt-1 w-40 overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,rgba(30,24,20,0.99),rgba(21,17,14,0.99))]"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onToggleLock();
+            }}
+            className={itemClass}
+          >
+            {locked ? "Unlock thread" : "Lock thread"}
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => {
+              setOpen(false);
+              onToggleLatestFirst();
+            }}
+            className={itemClass}
+          >
+            {latestFirst ? "Show oldest first" : "Show latest first"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Follow-ups to the forum Reddit-style refinement: fixes the Following-tab reply count (post_count includes the OP), adds Load-more pagination to the Following/Bookmarked feeds (previously silently capped at 20), flattens personal-feed rows into the same divided container as Discover, and moves the thread-page admin Lock/ordering controls behind a "⋯" menu matching the feed's kebab pattern. Documented in docs/FORUM_REDDIT_REFINEMENT.md §3b.