### PR TITLE
Uat

### DIFF
--- a/src/components/SocialLinks.tsx
+++ b/src/components/SocialLinks.tsx
@@ -1,3 +1,5 @@
+import { REDDIT_COMMUNITY, REDDIT_URL } from "../config/site";
+
 type Props = {
   variant?: "header" | "footer" | "inline";
 };
@@ -15,21 +17,47 @@ const SocialLinks = ({ variant = "inline" }: Props) => {
       ? "hover:underline"
       : "text-pink-500 hover:underline";
 
+  const wrapClass =
+    variant === "inline"
+      ? "inline-flex items-baseline gap-1.5"
+      : "flex items-center gap-3";
+
   return (
-    <a
-      href="https://instagram.com/toonranks"
-      target="_blank"
-      rel="noopener noreferrer"
-      className={linkClass}
-      title="Follow us on Instagram"
-    >
-      <img
-        src="https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png"
-        alt="Instagram"
-        className={iconClass}
-      />
-      {variant === "inline" && "Instagram"}
-    </a>
+    <span className={wrapClass}>
+      <a
+        href="https://instagram.com/toonranks"
+        target="_blank"
+        rel="noopener noreferrer"
+        className={linkClass}
+        title="Follow us on Instagram"
+      >
+        <img
+          src="https://upload.wikimedia.org/wikipedia/commons/a/a5/Instagram_icon.png"
+          alt="Instagram"
+          className={iconClass}
+        />
+        {variant === "inline" && "Instagram"}
+      </a>
+      {variant === "inline" && <span aria-hidden="true">·</span>}
+      <a
+        href={REDDIT_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={
+          variant === "inline"
+            ? "text-orange-600 hover:underline dark:text-orange-400"
+            : linkClass
+        }
+        title={`Join ${REDDIT_COMMUNITY} on Reddit`}
+      >
+        {/* Reddit "snoo" mark (Simple Icons path), brand orange. */}
+        <svg viewBox="0 0 24 24" className={iconClass} fill="#FF4500" role="img">
+          <title>Reddit</title>
+          <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.688-.561-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z" />
+        </svg>
+        {variant === "inline" && REDDIT_COMMUNITY}
+      </a>
+    </span>
   );
 };
 

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -6,6 +6,10 @@ export const OPERATOR_NAME = "Nofara LLC";
 export const ANDROID_PACKAGE = "com.toonranks.mobile";
 export const PLAY_STORE_URL = `https://play.google.com/store/apps/details?id=${ANDROID_PACKAGE}`;
 
+// Official community subreddit.
+export const REDDIT_COMMUNITY = "r/ToonRanks";
+export const REDDIT_URL = "https://www.reddit.com/r/ToonRanks/";
+
 export const SUPPORT_EMAIL = "support@toonranks.com";
 export const VERIFICATION_EMAIL = "noreply@toonranks.com";
 export const PASSWORD_RESET_EMAIL = "accounts@toonranks.com";


### PR DESCRIPTION
## Summary
- Add REDDIT_URL / REDDIT_COMMUNITY to site config.
- SocialLinks now renders Reddit (inline snoo SVG, brand orange) beside Instagram
  in all variants — footer Follow chip, header menu, and inline About/Contact copy.

## Test plan
- [ ] Footer chip, header menu, About and Contact all show the Reddit link
- [ ] Opens https://www.reddit.com/r/ToonRanks/ in a new tab
- [ ] Legible in light + dark mode; lint/build/tests pass