### PR TITLE
Uat

### DIFF
--- a/src/components/RichReplyEditor.tsx
+++ b/src/components/RichReplyEditor.tsx
@@ -183,20 +183,21 @@ export default function RichReplyEditor({
   }
 
   async function runMentionSearch(q: string) {
-    try {
-      const [seriesResults, users] = await Promise.all([
-        forumSeriesSearch(q),
-        searchUsers(q, 5),
-      ]);
-      setResults(seriesResults);
-      setUserResults(users);
-      setHighlight(0);
-      setMenuOpen(seriesResults.length > 0 || users.length > 0);
-    } catch {
-      setResults([]);
-      setUserResults([]);
-      setMenuOpen(false);
+    // allSettled so one failing endpoint doesn't blank the other's results —
+    // Promise.all here made a single failure silently kill the whole menu.
+    const [series, users] = await Promise.allSettled([
+      forumSeriesSearch(q),
+      searchUsers(q, 5),
+    ]);
+    const seriesOk = series.status === "fulfilled" ? series.value : [];
+    const usersOk = users.status === "fulfilled" ? users.value : [];
+    if (series.status === "rejected" && users.status === "rejected") {
+      console.warn("[mentions] both search endpoints failed", series.reason);
     }
+    setResults(seriesOk);
+    setUserResults(usersOk);
+    setHighlight(0);
+    setMenuOpen(seriesOk.length > 0 || usersOk.length > 0);
   }
 
   function insertUserMention(

--- a/src/components/RichTextComposer.tsx
+++ b/src/components/RichTextComposer.tsx
@@ -198,18 +198,23 @@ const RichTextComposer = forwardRef<
 
   async function runSearch(q: string) {
     const seq = ++searchSeq.current;
-    try {
-      const [series, users] = await Promise.all([
-        forumSeriesSearch(q),
-        searchUsers(q, 5),
-      ]);
-      if (seq !== searchSeq.current) return; // stale response
-      setSeriesResults(series);
-      setUserResults(users);
-      setHighlight(0);
-    } catch {
-      if (seq === searchSeq.current) closeMenu();
+    // allSettled so one failing endpoint doesn't blank the other's results —
+    // Promise.all here made a single failure silently kill the whole menu.
+    const [series, users] = await Promise.allSettled([
+      forumSeriesSearch(q),
+      searchUsers(q, 5),
+    ]);
+    if (seq !== searchSeq.current) return; // stale response
+    const seriesOk = series.status === "fulfilled" ? series.value : [];
+    const usersOk = users.status === "fulfilled" ? users.value : [];
+    if (series.status === "rejected" && users.status === "rejected") {
+      console.warn("[mentions] both search endpoints failed", series.reason);
+      closeMenu();
+      return;
     }
+    setSeriesResults(seriesOk);
+    setUserResults(usersOk);
+    setHighlight(0);
   }
 
   function pickSeries(r: ForumSeriesRef) {

--- a/src/components/UserTags.tsx
+++ b/src/components/UserTags.tsx
@@ -1,0 +1,112 @@
+import { ShieldCheck, Sparkles, Star, MessageSquareText } from "lucide-react";
+
+/**
+ * Small identity/activity tags shown right after a username, so anyone can
+ * tell at a glance what kind of user they're reading:
+ *
+ * - Admin      (role)                 — runs the place
+ * - Curator    (CONTRIBUTOR role)     — submits series to the catalog
+ * - Critic     (10+ series rated)     — backbone of the rankings
+ * - Chatterbox (25+ forum posts)      — keeps the forum alive
+ *
+ * Role tags render wherever posts/threads/profiles expose `role`. Activity
+ * tags render only where the API already provides the stats (leaderboard,
+ * public profile) — never guessed client-side. The existing crown RankerBadge
+ * (top-10 leaderboard) and the thread "OP" pill complete the set.
+ */
+
+const CRITIC_MIN_RATED = 10;
+const CHATTERBOX_MIN_POSTS = 25;
+
+const pillBase =
+  "inline-flex items-center gap-0.5 rounded px-1 py-px align-middle text-[10px] font-bold uppercase leading-none tracking-wide";
+
+type Tag = {
+  key: string;
+  label: string;
+  title: string;
+  className: string;
+  Icon: typeof ShieldCheck;
+};
+
+function tagsFor({
+  role,
+  seriesRated,
+  postCount,
+}: {
+  role?: string | null;
+  seriesRated?: number;
+  postCount?: number;
+}): Tag[] {
+  const tags: Tag[] = [];
+  const normalized = String(role || "").toUpperCase();
+
+  if (normalized === "ADMIN") {
+    tags.push({
+      key: "admin",
+      label: "Admin",
+      title: "Toon Ranks staff",
+      className:
+        "bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-300",
+      Icon: ShieldCheck,
+    });
+  } else if (normalized === "CONTRIBUTOR") {
+    tags.push({
+      key: "curator",
+      label: "Curator",
+      title: "Contributor — submits series to the catalog",
+      className: "bg-sky-100 text-sky-700 dark:bg-sky-950/50 dark:text-sky-300",
+      Icon: Sparkles,
+    });
+  }
+
+  if ((seriesRated ?? 0) >= CRITIC_MIN_RATED) {
+    tags.push({
+      key: "critic",
+      label: "Critic",
+      title: `Rated ${seriesRated} series`,
+      className:
+        "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-300",
+      Icon: Star,
+    });
+  }
+
+  if ((postCount ?? 0) >= CHATTERBOX_MIN_POSTS) {
+    tags.push({
+      key: "chatterbox",
+      label: "Chatterbox",
+      title: `${postCount} forum posts`,
+      className:
+        "bg-violet-100 text-violet-700 dark:bg-violet-950/50 dark:text-violet-300",
+      Icon: MessageSquareText,
+    });
+  }
+
+  return tags;
+}
+
+export default function UserTags({
+  role,
+  seriesRated,
+  postCount,
+  className,
+}: {
+  role?: string | null;
+  seriesRated?: number;
+  postCount?: number;
+  className?: string;
+}) {
+  const tags = tagsFor({ role, seriesRated, postCount });
+  if (tags.length === 0) return null;
+
+  return (
+    <span className={`inline-flex items-center gap-1 ${className ?? ""}`}>
+      {tags.map(({ key, label, title, className: pill, Icon }) => (
+        <span key={key} className={`${pillBase} ${pill}`} title={title}>
+          <Icon className="h-2.5 w-2.5" aria-hidden="true" />
+          {label}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/src/pages/ForumPage.tsx
+++ b/src/pages/ForumPage.tsx
@@ -36,6 +36,7 @@ import { NoticeModal } from "../components/NoticeModal";
 import UserAvatar from "../components/UserAvatar";
 import { RankerBadge } from "../components/RankerBadge";
 import { inlineUsernameClassName } from "../util/userDisplay";
+import UserTags from "../components/UserTags";
 import { getTopRankMap } from "../util/rankMap";
 import { timeAgo, fullTimestamp } from "../util/timeAgo";
 import RichTextComposer, {
@@ -660,6 +661,7 @@ export default function ForumPage() {
                             {t.author_username}
                           </span>
                         </Link>
+                        <UserTags role={t.author_role} />
                         <RankerBadge rank={rankMap[t.author_username]} />
                       </>
                     ) : (

--- a/src/pages/LeaderboardPage.tsx
+++ b/src/pages/LeaderboardPage.tsx
@@ -6,6 +6,7 @@ import {
   type LeaderboardPageOut,
 } from "../api/manApi";
 import UserAvatar from "../components/UserAvatar";
+import UserTags from "../components/UserTags";
 import { inlineUsernameClassName } from "../util/userDisplay";
 import { SITE_NAME } from "../config/site";
 
@@ -91,6 +92,12 @@ function RankerSpotlightCard({
         >
           {user.username}
         </p>
+        <UserTags
+          role={user.role}
+          seriesRated={user.series_rated}
+          postCount={user.post_count}
+          className="mt-1 justify-center"
+        />
         <p className={`mt-1 text-lg font-black sm:text-xl ${cpCls}`}>
           ◆ {formatCP(user.cred_score)}{" "}
           <span className="text-xs font-semibold opacity-75">CP</span>
@@ -133,6 +140,12 @@ function RankerRow({ user }: { user: LeaderboardUser }) {
         className={`min-w-0 flex-1 truncate text-sm font-semibold ${inlineUsernameClassName(user.role)}`}
       >
         {user.username}
+        <UserTags
+          role={user.role}
+          seriesRated={user.series_rated}
+          postCount={user.post_count}
+          className="ml-1.5"
+        />
       </span>
 
       {/* Cred Points */}

--- a/src/pages/ThreadPage.tsx
+++ b/src/pages/ThreadPage.tsx
@@ -41,6 +41,7 @@ import { PostVoteControl, type ForumVote } from "../components/PostVoteControl";
 import UserAvatar from "../components/UserAvatar";
 import { RankerBadge } from "../components/RankerBadge";
 import { inlineUsernameClassName } from "../util/userDisplay";
+import UserTags from "../components/UserTags";
 import { timeAgo, fullTimestamp } from "../util/timeAgo";
 import { getTopRankMap } from "../util/rankMap";
 import { wasEdited } from "../util/dateUtils";
@@ -701,8 +702,6 @@ export default function ThreadPage() {
   // 🔧 edit state kept in ThreadPage and passed down
   const [editPostId, setEditPostId] = useState<number | null>(null);
   const [editContent, setEditContent] = useState<string>("");
-  const [originalReplyComposerOpen, setOriginalReplyComposerOpen] =
-    useState(false);
 
   const notice = useNotice();
   const [rankMap, setRankMap] = useState<Record<string, number>>({});
@@ -1005,6 +1004,7 @@ export default function ThreadPage() {
                               {posts[0].author_username}
                             </span>
                           </Link>
+                          <UserTags role={posts[0].author_role} />
                           <span
                             className="rounded bg-blue-100 px-1 py-px text-[10px] font-bold uppercase leading-none tracking-wide text-blue-700 dark:bg-blue-950/50 dark:text-blue-300"
                             title="Original poster"
@@ -1087,74 +1087,9 @@ export default function ThreadPage() {
                       }
                     }}
                   />
-                  {!thread?.latest_first ? (
-                    !thread?.locked || isAdmin ? (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setOriginalReplyComposerOpen((open) => !open)
-                        }
-                        aria-expanded={originalReplyComposerOpen}
-                        className="inline-flex items-center px-1.5 py-1 text-sm font-medium text-blue-700 transition hover:text-blue-800 dark:text-blue-300 dark:hover:text-blue-200"
-                      >
-                        Reply
-                      </button>
-                    ) : (
-                      <span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/30 dark:text-amber-200">
-                        Replies are locked.
-                      </span>
-                    )
-                  ) : null}
-                  {!thread?.latest_first &&
-                    originalReplyComposerOpen &&
-                    (!thread?.locked || isAdmin) && (
-                      <div className="mt-2 w-full basis-full">
-                        <RichReplyEditor
-                          compact
-                          threadId={threadId}
-                          onCancel={() => setOriginalReplyComposerOpen(false)}
-                          onSubmit={async (content, seriesIds) => {
-                            if (!user) {
-                              notice.show({
-                                message:
-                                  "You need to be logged in to post a reply.",
-                                title: "Sign in required",
-                                variant: "warning",
-                              });
-                              return;
-                            }
-
-                            const trimmed = content.trim();
-                            if (!trimmed) {
-                              notice.show({
-                                message: "Reply cannot be empty.",
-                                title: "Cannot post",
-                                variant: "warning",
-                              });
-                              return;
-                            }
-
-                            try {
-                              const p = await createForumPost(threadId, {
-                                content_markdown: trimmed,
-                                series_ids: seriesIds,
-                                parent_id: posts[0].id,
-                              });
-                              setPosts((prev) => [...prev, p]);
-                              setOriginalReplyComposerOpen(false);
-                            } catch (err: unknown) {
-                              notice.show({
-                                message:
-                                  getErrorMessage(err) ||
-                                  "Failed to post reply.",
-                                title: "Post failed",
-                                variant: "error",
-                              });
-                            }
-                          }}
-                        />
-                      </div>
-                    )}
+                  {/* The OP's own Reply control was removed as redundant — the
+                      main composer sits directly below this post and opening a
+                      second editor stacked on it read as a bug. */}
                 </div>
 
                 {/* Reply composer — directly under the original post (Reddit-style),
@@ -1800,6 +1735,7 @@ function ReplyBranch({
                       {post.author_username}
                     </span>
                   </Link>
+                  <UserTags role={post.author_role} />
                   {isOp && (
                     <span
                       className="rounded bg-blue-100 px-1 py-px text-[10px] font-bold uppercase leading-none tracking-wide text-blue-700 dark:bg-blue-950/50 dark:text-blue-300"


### PR DESCRIPTION
## Summary
- Remove the OP's redundant Reply control (opened a second editor stacked on the
  main composer directly below it).
- Mention search: Promise.allSettled + console warning — one failing endpoint no
  longer silently kills the whole dropdown. (The reported "@series broken" was
  .env.local pointing at a stopped local backend; production was unaffected.)
- New UserTags pills after usernames: Admin, Curator (contributor), Critic (10+
  rated), Chatterbox (25+ posts) — wired into threads, forum list, leaderboard.

## Test plan
- [ ] No duplicate reply editor on the OP; composer + locked notice intact
- [ ] @mentions work with backend up; console warning when unreachable
- [ ] Tags render on leaderboard (Critic visible with live data) and threads
- [ ] Light/dark legible; lint/build/tests pass