### PR TITLE
Mention multiword search

### DIFF
--- a/src/components/RichReplyEditor.tsx
+++ b/src/components/RichReplyEditor.tsx
@@ -164,21 +164,22 @@ export default function RichReplyEditor({
   function detectAtToken(nextValue: string, caret: number) {
     if (caret < 0 || caret > nextValue.length) return null;
     const before = nextValue.slice(0, caret);
-    const lastBoundary = Math.max(
-      before.lastIndexOf(" "),
-      before.lastIndexOf("\n"),
-      before.lastIndexOf("\t"),
-      before.lastIndexOf("("),
-      before.lastIndexOf("[")
-    );
-    const tokenStart = lastBoundary + 1;
-    const token = nextValue.slice(tokenStart, caret);
-    if (!token.startsWith("@")) return null;
+    // Anchor to the LAST "@" before the caret so the query may contain spaces
+    // (multi-word titles like "@The Legend of…"). Same limits as the rich
+    // editor: no newline, must not start with whitespace, capped at 60 chars.
+    // Over-matching after prose self-limits — empty results close the menu.
+    const tokenStart = before.lastIndexOf("@");
+    if (tokenStart === -1) return null;
+    const prev = tokenStart === 0 ? "" : before[tokenStart - 1];
+    if (prev && !/[\s([]/.test(prev)) return null;
+    const query = before.slice(tokenStart + 1, caret);
+    if (query.length > 60 || query.includes("\n") || /^\s/.test(query))
+      return null;
+    // Extend past the caret to the end of the current word so picking a result
+    // mid-word replaces the whole word.
     const after = nextValue.slice(caret);
     const m = after.match(/^[^\s.,!?)]*/);
     const tokenEnd = caret + (m ? m[0].length : 0);
-    const wholeToken = nextValue.slice(tokenStart, tokenEnd);
-    const query = wholeToken.slice(1);
     return { tokenStart, tokenEnd, query };
   }
 

--- a/src/components/RichTextComposer.tsx
+++ b/src/components/RichTextComposer.tsx
@@ -111,14 +111,22 @@ export type RichTextComposerHandle = {
 
 type MentionHit = { from: number; to: number; query: string };
 
-/** Find an "@query" token immediately before the caret in the current text block. */
+/**
+ * Find an "@query" token immediately before the caret in the current text block.
+ *
+ * The query may contain spaces so multi-word titles ("@The Legend of the…")
+ * keep matching — it just can't contain another "@" (which anchors the match to
+ * the LAST "@" before the caret), can't start with whitespace, and is capped at
+ * 60 chars. Over-matching after ordinary prose ("@user thanks for the rec") is
+ * self-limiting: once the search returns nothing, the menu closes.
+ */
 function detectMention(editor: Editor): MentionHit | null {
   const { $from, empty } = editor.state.selection;
   if (!empty) return null;
   const textBefore = $from.parent.textBetween(0, $from.parentOffset, "￼");
-  const m = textBefore.match(/(^|[\s([])@([^\s@]*)$/);
+  const m = textBefore.match(/(^|[\s([])@([^\s@][^@]{0,59})?$/);
   if (!m) return null;
-  const query = m[2];
+  const query = m[2] ?? "";
   const tokenLen = query.length + 1; // include "@"
   const from = $from.pos - tokenLen;
   return { from, to: $from.pos, query };


### PR DESCRIPTION
## Summary
- Mention detection in both editors (rich + markdown) now anchors to the last "@"
  before the caret and permits spaces in the query, so multi-word series titles
  ("@The Legend of…") keep the dropdown open. Capped at 60 chars, stops at
  newline/leading-space; empty results still close the menu so prose after a
  mention doesn't retrigger it.

## Test plan
- [ ] "@the Le" keeps the dropdown open and finds The Legend of the Northern Blade
- [ ] Works in both rich and markdown editors
- [ ] Prose after a completed mention doesn't reopen the menu
- [ ] lint/build/tests pass