### PR TITLE
Reading list polish

### DIFF
--- a/src/components/ReadingListShimmers.tsx
+++ b/src/components/ReadingListShimmers.tsx
@@ -64,3 +64,64 @@ export const ItemRowsShimmerBlock: React.FC<{ count?: number }> = ({
     ))}
   </ul>
 );
+
+/**
+ * Loading skeleton for the PUBLIC shared-list page (/lists/:token), matching
+ * that page's three share layouts so the placeholders have the same shape and
+ * grid as the content that replaces them (no layout jump). The row shimmers
+ * above belong to the owner's My Lists page, not here.
+ */
+export const SharedListShimmerBlock: React.FC<{
+  layout?: "cards" | "poster" | "compact";
+  count?: number;
+}> = ({ layout = "cards", count = 6 }) => {
+  if (layout === "compact") {
+    return (
+      <div className="grid grid-cols-1 gap-3">
+        {Array.from({ length: count }).map((_, i) => (
+          <div
+            key={i}
+            className="grid grid-cols-[4.75rem_minmax(0,1fr)] items-center gap-4 rounded-[22px] border border-slate-200 bg-white/90 p-3 dark:border-[#342a23] dark:bg-[#15110f]/90"
+          >
+            <ShimmerBox className="h-24 w-full rounded-2xl" />
+            <div className="min-w-0 space-y-2">
+              <div className="flex gap-2">
+                <ShimmerBox className="h-5 w-14 rounded-full" />
+                <ShimmerBox className="h-5 w-16 rounded-full" />
+              </div>
+              <ShimmerBox className="h-5 w-2/3 rounded" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (layout === "poster") {
+    return (
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-5">
+        {Array.from({ length: count }).map((_, i) => (
+          <ShimmerBox key={i} className="aspect-[2/3] w-full rounded-[26px]" />
+        ))}
+      </div>
+    );
+  }
+
+  // cards (default share layout)
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className="overflow-hidden rounded-[28px] border border-slate-200 bg-white/90 dark:border-[#342a23] dark:bg-[#15110f]/90"
+        >
+          <ShimmerBox className="aspect-[2/3] w-full rounded-none" />
+          <div className="space-y-2 p-4">
+            <ShimmerBox className="h-6 w-3/4 rounded" />
+            <ShimmerBox className="h-3 w-1/3 rounded" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/src/pages/MyReadingListsPage.tsx
+++ b/src/pages/MyReadingListsPage.tsx
@@ -783,12 +783,13 @@ export default function MyReadingListsPage() {
         return Array.from(map.values()).sort((a, b) => b.id - a.id);
       });
 
-      // ✅ NEW: expand all newly fetched lists by default
+      // Lists start collapsed by default — a compact overview scans better and
+      // items only load when a list is expanded. User toggles are preserved.
       setOpen((prev) => {
         const nextOpen: Record<number, boolean> = { ...prev };
         for (const l of res.items) {
-          // only set true if the user hasn't explicitly toggled this one before
-          if (prev[l.id] === undefined) nextOpen[l.id] = true;
+          // only set if the user hasn't explicitly toggled this one before
+          if (prev[l.id] === undefined) nextOpen[l.id] = false;
         }
         return nextOpen;
       });

--- a/src/pages/PublicReadingListPage.tsx
+++ b/src/pages/PublicReadingListPage.tsx
@@ -8,7 +8,7 @@ import {
   type PublicReadingList,
   type RankedSeries,
 } from "../api/manApi";
-import { ItemRowsShimmerBlock } from "../components/ReadingListShimmers";
+import { SharedListShimmerBlock } from "../components/ReadingListShimmers";
 import ShimmerBox from "../components/ShimmerBox";
 import {
   filterItemsByType,
@@ -412,7 +412,7 @@ export default function PublicReadingListPage() {
           <title>{pageTitle}</title>
           <meta name="robots" content="noindex,follow" />
         </Helmet>
-        <ItemRowsShimmerBlock count={6} />
+        <SharedListShimmerBlock layout={layout} count={6} />
       </div>
     );
   }
@@ -559,10 +559,16 @@ export default function PublicReadingListPage() {
           This list is empty.
         </div>
       ) : summariesLoading && Object.keys(summaries).length === 0 ? (
-        <ItemRowsShimmerBlock count={Math.min(list.items.length, 8)} />
+        <SharedListShimmerBlock
+          layout={layout}
+          count={Math.min(list.items.length, 8)}
+        />
       ) : isFiltered && !typesResolved ? (
         // Still loading the types we need before we can filter the full list.
-        <ItemRowsShimmerBlock count={Math.min(list.items.length, 8)} />
+        <SharedListShimmerBlock
+          layout={layout}
+          count={Math.min(list.items.length, 8)}
+        />
       ) : isFiltered && matchCount === 0 ? (
         <div className="rounded-[24px] border border-dashed border-slate-300 bg-white/80 px-6 py-12 text-center text-slate-600 shadow-sm dark:border-[#3a3028] dark:bg-[linear-gradient(145deg,_rgba(26,21,18,0.95),_rgba(19,16,13,0.95))] dark:text-slate-300">
           No{" "}
@@ -592,7 +598,7 @@ export default function PublicReadingListPage() {
           }
         >
           {visibleItems.length === 0 && summariesLoading ? (
-            <ItemRowsShimmerBlock count={6} />
+            <SharedListShimmerBlock layout={layout} count={6} />
           ) : (
             <section className="relative overflow-hidden rounded-[28px] border border-slate-200 bg-white/70 p-4 pb-10 shadow-[0_22px_55px_-40px_rgba(15,23,42,0.45)] backdrop-blur-sm dark:border-[#342a23] dark:bg-[#100d0b]/80 sm:p-5 sm:pb-11">
               <div className={layoutGridClass}>


### PR DESCRIPTION
Two reading-list polish fixes. The public shared-list page (/lists/:token) was using the row-style shimmer from the owner's My Lists page while its content renders as a card grid — it now has a layout-aware skeleton (SharedListShimmerBlock) matching all three share layouts, used for initial load, filter resolution, and pagination states. Separately, My Lists now defaults each list to collapsed instead of expanded — a compact overview that also avoids eagerly fetching every list's items; user toggles are preserved. Typecheck, lint, unit tests, and SSR build pass.
