### PR TITLE
Fix search filters

### DIFF
--- a/src/pages/FilteredSeriesPage.tsx
+++ b/src/pages/FilteredSeriesPage.tsx
@@ -23,6 +23,7 @@ import ShimmerLoader from "../components/ShimmerLoader";
 import { useSearch } from "../components/useSearch";
 import { useUser } from "../login/useUser";
 import { isAdminUser } from "../util/roleUtils";
+import { applySearchFilters } from "../util/searchFilter";
 import {
   absoluteUrl,
   DEFAULT_SOCIAL_IMAGE,
@@ -71,6 +72,9 @@ const FilteredSeriesPage = () => {
   const initialItems =
     (useLoaderData() as { items?: RankedSeries[] } | null)?.items ?? [];
   const [items, setItems] = useState<RankedSeries[]>(initialItems);
+  // Raw, type-scoped search matches; genre/status/sort are applied client-side
+  // (the search endpoint can't) — see `searchView`.
+  const [searchResults, setSearchResults] = useState<RankedSeries[]>([]);
   const skipInitialLoad = useRef(initialItems.length > 0);
   const [page, setPage] = useState(1);
   const [hasMore, setHasMore] = useState(true);
@@ -101,10 +105,31 @@ const FilteredSeriesPage = () => {
     []
   );
 
+  const isSearching = searchTerm.trim().length > 0;
+
+  // Search matches with the toolbar's genre/status filters + sort applied
+  // client-side, so those controls work during a text search.
+  const searchView = useMemo(
+    () =>
+      applySearchFilters(searchResults, {
+        genre: activeGenre,
+        status: activeStatus,
+        sort: sortBy,
+      }),
+    [searchResults, activeGenre, activeStatus, sortBy]
+  );
+
+  // What the grid renders: the filtered/sorted search view while searching,
+  // otherwise the paginated rankings.
+  const displayedItems = isSearching ? searchView : items;
+
+  // Base the genre strip on the active dataset — the full search matches while
+  // searching (so every matchable genre is offered), otherwise loaded rankings.
+  const genreSource = isSearching ? searchResults : items;
   const derivedGenres = useMemo(() => {
     const set = new Set<string>();
 
-    for (const item of items) {
+    for (const item of genreSource) {
       if (!item?.genre) continue;
       String(item.genre)
         .split(",")
@@ -114,7 +139,7 @@ const FilteredSeriesPage = () => {
     }
 
     return Array.from(set);
-  }, [items, normalizeGenre]);
+  }, [genreSource, normalizeGenre]);
 
   // Accumulate genres so the strip never collapses when a filter narrows results.
   useEffect(() => {
@@ -218,19 +243,58 @@ const FilteredSeriesPage = () => {
     [hasMore, seriesType, activeGenre, activeStatus, sortBy]
   );
 
-  // Reset + load page 1 whenever the type, search term, or genre/status filters
-  // change. Text search uses the search endpoint (then narrows to the page type
-  // client-side); otherwise type + genre + status compose server-side.
+  // Fetch the raw (type-scoped) search matches when the term or type changes.
+  // Genre/status/sort are NOT deps — they're applied client-side in `searchView`
+  // so changing a filter re-orders/narrows the results without a refetch. The
+  // page's type is passed so the backend scopes both results AND rank to this
+  // category, keeping each result's true within-type rank.
+  useEffect(() => {
+    const term = searchTerm.trim();
+    if (!seriesType || !term) {
+      setSearchResults([]);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      try {
+        const all = await searchSeries(term, {
+          type: seriesType.toUpperCase(),
+        });
+        if (!cancelled) {
+          setSearchResults(all);
+          setHasMore(false);
+        }
+      } catch (err: unknown) {
+        if (!cancelled && !isRequestCanceled(err)) {
+          console.error("Search failed:", err);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [seriesType, searchTerm]);
+
+  // Reset + load page 1 of the type's rankings when the genre/status/sort
+  // filters change — but only while NOT searching (search is handled above and
+  // filtered client-side). type + genre + status compose server-side.
   useEffect(() => {
     if (!seriesType) return;
 
     // Skip the first run when the server already seeded page 1 (default filters)
-    // so we don't clear the SSR cards on hydration. Filter/search/type changes
-    // still reset + refetch.
+    // so we don't clear the SSR cards on hydration. Filter/type changes still
+    // reset + refetch.
     if (skipInitialLoad.current) {
       skipInitialLoad.current = false;
       return;
     }
+
+    if (searchTerm.trim()) return;
 
     controllerRef.current?.abort();
     const controller = new AbortController();
@@ -247,26 +311,15 @@ const FilteredSeriesPage = () => {
     const run = async () => {
       setLoading(true);
       try {
-        if (searchTerm.trim()) {
-          // Pass the page's type so the backend scopes both results AND rank to
-          // this category — each result keeps its true rank within the type,
-          // instead of being re-ranked among the search matches.
-          const all = await searchSeries(searchTerm.trim(), {
-            type: seriesType.toUpperCase(),
-          });
-          setItems(all);
-          setHasMore(false);
-        } else {
-          const all = await fetchRankedSeriesPaginated(1, PAGE_SIZE, {
-            type: seriesType.toUpperCase(),
-            genre: activeGenre ?? undefined,
-            status: activeStatus ?? undefined,
-            sort: sortBy,
-            signal: controller.signal,
-          });
-          setItems(all);
-          setHasMore(all.length >= PAGE_SIZE);
-        }
+        const all = await fetchRankedSeriesPaginated(1, PAGE_SIZE, {
+          type: seriesType.toUpperCase(),
+          genre: activeGenre ?? undefined,
+          status: activeStatus ?? undefined,
+          sort: sortBy,
+          signal: controller.signal,
+        });
+        setItems(all);
+        setHasMore(all.length >= PAGE_SIZE);
       } catch (err: unknown) {
         if (!isRequestCanceled(err)) {
           console.error("Failed to fetch series:", err);
@@ -317,7 +370,7 @@ const FilteredSeriesPage = () => {
       <section className="overflow-hidden rounded-[28px] border border-slate-200 bg-white/90 shadow-[0_24px_60px_-42px_rgba(15,23,42,0.45)] dark-theme-shell">
         <RankingsToolbar
           contextLabel={seriesType?.toUpperCase() ?? "Rankings"}
-          loadedCount={items.length}
+          loadedCount={displayedItems.length}
           activeStatus={activeStatus}
           activeGenre={activeGenre}
           genres={allGenres}
@@ -346,25 +399,27 @@ const FilteredSeriesPage = () => {
               <InfiniteScroll
                 className="no-scrollbar"
                 style={{ overflow: "visible" }}
-                dataLength={items.length}
+                dataLength={displayedItems.length}
                 next={() => setPage((prev) => prev + 1)}
-                hasMore={!searchTerm.trim() && hasMore}
+                hasMore={!isSearching && hasMore}
                 loader={
-                  items.length > 0 ? (
+                  displayedItems.length > 0 ? (
                     <p className="py-6 text-center text-gray-500 dark:text-slate-400">Loading...</p>
                   ) : null
                 }
                 endMessage={
-                  !loading && items.length > 0 ? (
+                  !loading && displayedItems.length > 0 ? (
                     <p className="py-6 text-center text-gray-400 dark:text-slate-500">
                       You've seen everything. New series are added periodically.
                     </p>
                   ) : null
                 }
               >
-                {items.length === 0 && loading ? <ShimmerLoader /> : null}
+                {displayedItems.length === 0 && loading ? (
+                  <ShimmerLoader />
+                ) : null}
 
-                {items.length === 0 && !loading ? (
+                {displayedItems.length === 0 && !loading ? (
                   <div className="py-12 text-center text-gray-600 dark:text-slate-300">
                     <p className="mb-3">
                       {activeGenre || activeStatus
@@ -387,9 +442,9 @@ const FilteredSeriesPage = () => {
                   </div>
                 ) : null}
 
-                {items.length > 0 ? (
+                {displayedItems.length > 0 ? (
                   <div className="grid grid-cols-2 gap-x-3 gap-y-5 sm:grid-cols-3 sm:gap-x-4 sm:gap-y-6 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
-                    {items.map((item, i) => (
+                    {displayedItems.map((item, i) => (
                       <ManCard
                         key={item.id}
                         index={i < PAGE_SIZE ? i : undefined}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -22,6 +22,7 @@ import { useUser } from "../login/useUser";
 import ReadingListModal from "../components/ReadingListModal";
 import RankingsToolbar, { type SortValue } from "../components/RankingsToolbar";
 import { canSubmitSeriesUser, isAdminUser } from "../util/roleUtils";
+import { applySearchFilters } from "../util/searchFilter";
 import {
   absoluteUrl,
   DEFAULT_SOCIAL_IMAGE,
@@ -98,6 +99,10 @@ const Home = () => {
   const [showModal, setShowModal] = useState(false);
   const [editItem, setEditItem] = useState<Series | null>(null);
   const [items, setItems] = useState<RankedSeries[]>(initialItems);
+  // Raw, unfiltered matches for the current search term. The search endpoint
+  // only accepts the query (+ optional type), so genre/status/sort are applied
+  // client-side (see `searchView`) without refetching on every filter change.
+  const [searchResults, setSearchResults] = useState<RankedSeries[]>([]);
   const { searchTerm } = useSearch();
   // Skip the first client load when the server already seeded page 1 (default
   // filters), so we don't clear the SSR cards on hydration. But when we mount
@@ -129,6 +134,25 @@ const Home = () => {
   const isAdmin = isAdminUser(user);
   const canSubmitSeries = canSubmitSeriesUser(user);
 
+  const isSearching = searchTerm.trim().length > 0;
+
+  // Search matches with the genre/status filters + sort applied client-side, so
+  // the toolbar controls work during a text search (the search API can't do it
+  // server-side).
+  const searchView = useMemo(
+    () =>
+      applySearchFilters(searchResults, {
+        genre: activeGenre,
+        status: activeStatus,
+        sort: sortBy,
+      }),
+    [searchResults, activeGenre, activeStatus, sortBy]
+  );
+
+  // What the grid renders: the filtered/sorted search view while searching,
+  // otherwise the paginated rankings.
+  const displayedItems = isSearching ? searchView : items;
+
   // Normalize a single genre label (e.g., "sci-fi" -> "Sci-Fi")
   const normalizeGenre = useCallback(
     (g: string) =>
@@ -140,10 +164,13 @@ const Home = () => {
     []
   );
 
-  // Genres seen in the currently loaded items
+  // Genres seen in the active dataset — the full search matches while searching
+  // (so every matchable genre is offered in the strip), otherwise the loaded
+  // rankings.
+  const genreSource = isSearching ? searchResults : items;
   const derivedGenres = useMemo(() => {
     const set = new Set<string>();
-    for (const it of items) {
+    for (const it of genreSource) {
       if (!it?.genre) continue;
       // support comma-separated genres like "Action, Thriller"
       const pieces = String(it.genre)
@@ -153,7 +180,7 @@ const Home = () => {
       pieces.forEach((p) => set.add(p));
     }
     return Array.from(set);
-  }, [items, normalizeGenre]);
+  }, [genreSource, normalizeGenre]);
 
   // Accumulate genres across loads so the strip only grows (and stays usable
   // even when a genre filter narrows the result set to a single genre).
@@ -276,50 +303,76 @@ const Home = () => {
   //   return compareList.some((item) => item.id === id);
   // };
 
-  // Reset and load page 1 whenever the search term or active filters change.
-  // Text search (from the nav bar) and the genre+status filters are separate
-  // modes: searching uses the search endpoint; otherwise genre + status compose
-  // server-side on the rankings endpoint.
+  // Fetch the raw search matches when the term changes. Genre/status/sort are
+  // NOT deps here — they're applied client-side in `searchView`, so changing a
+  // filter re-orders/narrows the existing results instead of refetching.
+  useEffect(() => {
+    const term = searchTerm.trim();
+    if (!term) {
+      setSearchResults([]);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      try {
+        setLoading(true);
+        const results = await searchSeries(term);
+        if (!cancelled) {
+          setSearchResults(results);
+          setHasMore(false);
+        }
+      } catch (err) {
+        if (!cancelled) console.error("Search failed:", err);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchTerm]);
+
+  // Reset + load page 1 of the rankings whenever the genre/status/sort filters
+  // change — but only while NOT searching (search is handled above and filtered
+  // client-side). Composes genre + status + sort server-side on the rankings
+  // endpoint.
   useEffect(() => {
     if (skipInitialLoad.current) {
       skipInitialLoad.current = false;
       return;
     }
-    const fetchData = async () => {
-      if (searchTerm.trim()) {
-        try {
-          setLoading(true);
-          const results = await searchSeries(searchTerm);
-          setItems(results);
-          setHasMore(false);
-        } catch (err) {
-          console.error("Search failed:", err);
-        } finally {
-          setLoading(false);
-        }
-      } else {
-        setLoading(true);
-        setItems([]);
-        setPage(1);
-        setHasMore(true);
+    if (searchTerm.trim()) return;
 
-        try {
-          const results = await fetchRankedSeriesPaginated(1, PAGE_SIZE, {
-            genre: activeGenre ?? undefined,
-            status: activeStatus ?? undefined,
-            sort: sortBy,
-          });
+    setLoading(true);
+    setItems([]);
+    setPage(1);
+    setHasMore(true);
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const results = await fetchRankedSeriesPaginated(1, PAGE_SIZE, {
+          genre: activeGenre ?? undefined,
+          status: activeStatus ?? undefined,
+          sort: sortBy,
+        });
+        if (!cancelled) {
           setItems(results);
           if (results.length < PAGE_SIZE) setHasMore(false);
-        } catch (err) {
-          console.error("Failed to fetch default ranked series:", err);
-        } finally {
-          setLoading(false);
         }
+      } catch (err) {
+        if (!cancelled)
+          console.error("Failed to fetch default ranked series:", err);
+      } finally {
+        if (!cancelled) setLoading(false);
       }
-    };
+    })();
 
-    fetchData();
+    return () => {
+      cancelled = true;
+    };
   }, [searchTerm, activeGenre, activeStatus, sortBy]);
 
   useEffect(() => {
@@ -380,7 +433,7 @@ const Home = () => {
         <section className="overflow-hidden rounded-[28px] border border-slate-200 bg-white/90 shadow-[0_24px_60px_-42px_rgba(15,23,42,0.45)] dark-theme-shell">
           <RankingsToolbar
             contextLabel="Rankings"
-            loadedCount={items.length}
+            loadedCount={displayedItems.length}
             activeStatus={activeStatus}
             activeGenre={activeGenre}
             genres={allGenres}
@@ -437,11 +490,11 @@ const Home = () => {
           <CompareManager>
             {({ toggleCompare, isSelectedForCompare }) => (
               <InfiniteScroll
-                dataLength={items.length}
+                dataLength={displayedItems.length}
                 next={() => setPage((prev) => prev + 1)}
-                hasMore={!searchTerm && hasMore}
+                hasMore={!isSearching && hasMore}
                 loader={
-                  items.length > 0 ? (
+                  displayedItems.length > 0 ? (
                     <div className="flex justify-center py-6">
                       <div className="w-6 h-6 border-4 border-blue-400 border-t-transparent rounded-full animate-spin" />
                     </div>
@@ -453,11 +506,11 @@ const Home = () => {
                   </p>
                 }
               >
-                {items.length === 0 && loading ? (
+                {displayedItems.length === 0 && loading ? (
                   <ShimmerLoader />
                 ) : (
                   <div className="grid grid-cols-2 gap-x-3 gap-y-5 sm:grid-cols-3 sm:gap-x-4 sm:gap-y-6 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
-                    {items.map((item, i) => (
+                    {displayedItems.map((item, i) => (
                       <ManCard
                         key={item.id}
                         index={i < PAGE_SIZE ? i : undefined}

--- a/src/util/searchFilter.test.ts
+++ b/src/util/searchFilter.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { applySearchFilters } from "./searchFilter";
+import type { RankedSeries } from "../api/manApi";
+
+const make = (p: Partial<RankedSeries> & { id: number }): RankedSeries => ({
+  title: `S${p.id}`,
+  genre: "",
+  type: "MANHWA",
+  cover_url: "",
+  vote_count: 0,
+  final_score: 0,
+  rank: null,
+  ...p,
+});
+
+const data: RankedSeries[] = [
+  make({ id: 1, title: "Beta", genre: "Action, Fantasy", status: "ONGOING", vote_count: 10, final_score: 8.1 }),
+  make({ id: 2, title: "Alpha", genre: "Romance", status: "COMPLETE", vote_count: 50, final_score: 7.2 }),
+  make({ id: 3, title: "Gamma", genre: "Action, Drama", status: "ONGOING", vote_count: 30, final_score: 9.0 }),
+];
+
+describe("applySearchFilters", () => {
+  it("returns all items (score desc) with no filters", () => {
+    const out = applySearchFilters(data, {});
+    expect(out.map((s) => s.id)).toEqual([3, 1, 2]);
+  });
+
+  it("filters by genre (case-insensitive, comma lists)", () => {
+    const out = applySearchFilters(data, { genre: "action" });
+    expect(out.map((s) => s.id).sort()).toEqual([1, 3]);
+  });
+
+  it("filters by status", () => {
+    const out = applySearchFilters(data, { status: "COMPLETE" });
+    expect(out.map((s) => s.id)).toEqual([2]);
+  });
+
+  it("combines genre + status", () => {
+    const out = applySearchFilters(data, { genre: "Action", status: "ONGOING" });
+    expect(out.map((s) => s.id).sort()).toEqual([1, 3]);
+  });
+
+  it("sorts by votes desc", () => {
+    expect(applySearchFilters(data, { sort: "votes" }).map((s) => s.id)).toEqual([2, 3, 1]);
+  });
+
+  it("sorts by title A–Z", () => {
+    expect(applySearchFilters(data, { sort: "title" }).map((s) => s.title)).toEqual([
+      "Alpha",
+      "Beta",
+      "Gamma",
+    ]);
+  });
+
+  it("sorts newest by id desc (no date field)", () => {
+    expect(applySearchFilters(data, { sort: "newest" }).map((s) => s.id)).toEqual([3, 2, 1]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = data.slice();
+    const order = input.map((s) => s.id);
+    applySearchFilters(input, { sort: "title" });
+    expect(input.map((s) => s.id)).toEqual(order);
+  });
+
+  it("returns empty when nothing matches", () => {
+    expect(applySearchFilters(data, { genre: "Horror" })).toEqual([]);
+  });
+});

--- a/src/util/searchFilter.ts
+++ b/src/util/searchFilter.ts
@@ -1,0 +1,54 @@
+import type { RankedSeries, SeriesStatus } from "../api/manApi";
+import type { SortValue } from "../components/RankingsToolbar";
+
+export type SearchFilterOpts = {
+  genre?: string | null;
+  status?: SeriesStatus;
+  sort?: SortValue;
+};
+
+/**
+ * Apply the rankings toolbar's genre/status filters and sort to a set of search
+ * matches, client-side. The search endpoint only accepts the query (+ optional
+ * type), so the toolbar can't filter server-side during a text search — this
+ * makes those controls work on the returned results instead.
+ *
+ * Item ranks are left untouched; only which items appear and their order change,
+ * mirroring how the rankings grid behaves. Returns a new array (input untouched).
+ */
+export function applySearchFilters(
+  results: RankedSeries[],
+  { genre, status, sort = "score" }: SearchFilterOpts
+): RankedSeries[] {
+  const wantGenre = genre?.toLowerCase() ?? null;
+
+  const filtered = results.filter((s) => {
+    if (wantGenre) {
+      const has = String(s.genre ?? "")
+        .split(",")
+        .some((g) => g.trim().toLowerCase() === wantGenre);
+      if (!has) return false;
+    }
+    if (status && (s.status ?? "").toUpperCase() !== status) {
+      return false;
+    }
+    return true;
+  });
+
+  return filtered.sort((a, b) => {
+    switch (sort) {
+      case "votes":
+        return (b.vote_count ?? 0) - (a.vote_count ?? 0);
+      // RankedSeries has no date field; a higher id ≈ more recently added.
+      case "newest":
+        return b.id - a.id;
+      case "title":
+        return a.title.localeCompare(b.title, undefined, {
+          sensitivity: "base",
+        });
+      case "score":
+      default:
+        return (b.final_score ?? 0) - (a.final_score ?? 0);
+    }
+  });
+}


### PR DESCRIPTION
Search results ignored the Genre/Status/Sort toolbar controls because the /series/search endpoint only takes the query, and the pages set search results directly without filtering. Added a shared applySearchFilters util that applies genre/status filters + sort client-side to the matches, wired it into Home and FilteredSeriesPage, and split each page's data effect so search fetches only on term change (filters apply in-memory, no refetch) while rankings stays dormant during search. Adds unit tests for the util.
